### PR TITLE
Adjust the public exports for the `data_api` module

### DIFF
--- a/salesforce_functions/__init__.py
+++ b/salesforce_functions/__init__.py
@@ -1,5 +1,19 @@
 from ._internal.logging import get_logger
-from .context import Context
+from .context import Context, Org, User
+from .data_api.record import QueriedRecord, Record, RecordQueryResult
+from .data_api.reference_id import ReferenceId
+from .data_api.unit_of_work import UnitOfWork
 from .invocation_event import InvocationEvent
 
-__all__ = ["Context", "InvocationEvent", "get_logger"]
+__all__ = [
+    "Context",
+    "get_logger",
+    "InvocationEvent",
+    "Org",
+    "QueriedRecord",
+    "Record",
+    "RecordQueryResult",
+    "ReferenceId",
+    "UnitOfWork",
+    "User",
+]

--- a/salesforce_functions/context.py
+++ b/salesforce_functions/context.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 
 from .data_api import DataAPI
 
+__all__ = ["User", "Org", "Context"]
+
 
 @dataclass(frozen=True, slots=True)
 class User:

--- a/salesforce_functions/data_api/__init__.py
+++ b/salesforce_functions/data_api/__init__.py
@@ -18,6 +18,8 @@ from .record import Record, RecordQueryResult
 from .reference_id import ReferenceId
 from .unit_of_work import UnitOfWork
 
+__all__ = ["DataAPI"]
+
 T = TypeVar("T")
 
 

--- a/salesforce_functions/data_api/exceptions.py
+++ b/salesforce_functions/data_api/exceptions.py
@@ -1,5 +1,12 @@
 from dataclasses import dataclass
 
+__all__ = [
+    "InnerSalesforceRestApiError",
+    "DataApiError",
+    "MissingIdFieldError",
+    "UnexpectedRestApiResponsePayload",
+]
+
 
 @dataclass(frozen=True, slots=True)
 class InnerSalesforceRestApiError:

--- a/salesforce_functions/data_api/record.py
+++ b/salesforce_functions/data_api/record.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Any
 
+__all__ = ["Record", "QueriedRecord", "RecordQueryResult"]
+
 
 @dataclass(frozen=True, slots=True)
 class Record:

--- a/salesforce_functions/data_api/reference_id.py
+++ b/salesforce_functions/data_api/reference_id.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+__all__ = ["ReferenceId"]
+
 
 @dataclass(frozen=True, slots=True)
 class ReferenceId:

--- a/salesforce_functions/data_api/unit_of_work.py
+++ b/salesforce_functions/data_api/unit_of_work.py
@@ -7,6 +7,8 @@ from ._requests import (
 from .record import Record
 from .reference_id import ReferenceId
 
+__all__ = ["UnitOfWork"]
+
 
 class UnitOfWork:
     """

--- a/salesforce_functions/invocation_event.py
+++ b/salesforce_functions/invocation_event.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
+__all__ = ["InvocationEvent"]
+
 T = TypeVar("T")
 
 

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -1,5 +1,12 @@
 import pytest
 
+from salesforce_functions import (
+    QueriedRecord,
+    Record,
+    RecordQueryResult,
+    ReferenceId,
+    UnitOfWork,
+)
 from salesforce_functions.data_api import DataAPI
 from salesforce_functions.data_api.exceptions import (
     InnerSalesforceRestApiError,
@@ -7,13 +14,6 @@ from salesforce_functions.data_api.exceptions import (
     SalesforceRestApiError,
     UnexpectedRestApiResponsePayload,
 )
-from salesforce_functions.data_api.record import (
-    QueriedRecord,
-    Record,
-    RecordQueryResult,
-)
-from salesforce_functions.data_api.reference_id import ReferenceId
-from salesforce_functions.data_api.unit_of_work import UnitOfWork
 
 
 def new_data_api() -> DataAPI:


### PR DESCRIPTION
- Makes all of the public `data_api` module available from the root of the package, apart from exceptions and `DataAPI` itself. They are excluded to (a) reduce the noise when using IDE auto-completion, (b) (in the case of `DataAPI`) to help prevent accidental direct usage in case users weren't aware of `context.org.data_api`'s pre-configured client.
- Sets explicit `__all__` definitions on all public modules, to prevent imports from leaking into the public API.

GUS-W-12099003.