### PR TITLE
Add a test for `context.org.data_api`

### DIFF
--- a/invoke.sh
+++ b/invoke.sh
@@ -12,14 +12,14 @@ invocation_id="00Dxx0000006IYJEA2-4Y4W3Lw_LkoskcHdEaZze--MyFunction-$(openssl ra
 
 sfcontext=$(base64_encode <<'EOF'
 {
-  "apiVersion": "56.0",
+  "apiVersion": "53.0",
   "payloadVersion": "0.1",
   "userContext": {
     "orgId": "00Dxx0000006IYJ",
     "userId": "005xx000001X8Uz",
     "username": "user@example.tld",
-    "salesforceBaseUrl": "https://d8d000005zejveai-dev-ed.my.salesforce.com",
-    "orgDomainUrl": "https://d8d000005zejveai-dev-ed.my.salesforce.com"
+    "salesforceBaseUrl": "https://example-base-url.my.salesforce-sites.com",
+    "orgDomainUrl": "https://example-domain-url.my.salesforce.com"
   }
 }
 EOF

--- a/tests/fixtures/data_api/main.py
+++ b/tests/fixtures/data_api/main.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from salesforce_functions import Context, InvocationEvent, Record
+
+
+async def function(_event: InvocationEvent[Any], context: Context) -> str:
+    assert context.org is not None
+    record_id = await context.org.data_api.create(
+        Record(
+            "Movie__c",
+            fields={
+                "Name": "Star Wars Episode V: The Empire Strikes Back",
+                "Rating__c": "Excellent",
+            },
+        )
+    )
+    return record_id

--- a/tests/fixtures/returns_context/main.py
+++ b/tests/fixtures/returns_context/main.py
@@ -7,5 +7,5 @@ from salesforce_functions import Context, InvocationEvent
 async def function(_event: InvocationEvent[Any], context: Context) -> Context:
     # `context.org.data_api` is an instance of `DataAPI` which is not JSON serializable,
     # so it has to be replaced so that the function return value can be serialized.
-    org_without_data_api = dataclasses.replace(context.org, data_api=None)
+    org_without_data_api = dataclasses.replace(context.org, data_api="REMOVED")
     return dataclasses.replace(context, org=org_without_data_api)

--- a/tests/test_cloud_event.py
+++ b/tests/test_cloud_event.py
@@ -36,15 +36,15 @@ def test_cloud_event() -> None:
         subject="subject TODO",
         time="2022-11-01T12:00:00.000000Z",
         sf_context=SalesforceContext(
-            api_version="56.0",
+            api_version="53.0",
             payload_version="0.1",
             user_context=SalesforceUserContext(
                 org_id="00Dxx0000006IYJ",
                 user_id="005xx000001X8Uz",
                 on_behalf_of_user_id="another-user@example.tld",
                 username="user@example.tld",
-                salesforce_base_url="https://d8d000005zejveai-dev-ed.my.salesforce.com",
-                org_domain_url="https://d8d000005zejveai-dev-ed.my.salesforce.com",
+                salesforce_base_url="https://example-base-url.my.salesforce-sites.com",
+                org_domain_url="https://example-domain-url.my.salesforce.com",
             ),
         ),
         sf_function_context=SalesforceFunctionContext(
@@ -75,15 +75,15 @@ def test_minimal_cloud_event() -> None:
         subject=None,
         time=None,
         sf_context=SalesforceContext(
-            api_version="56.0",
+            api_version="53.0",
             payload_version="0.1",
             user_context=SalesforceUserContext(
                 org_id="00Dxx0000006IYJ",
                 user_id="005xx000001X8Uz",
                 on_behalf_of_user_id=None,
                 username="user@example.tld",
-                salesforce_base_url="https://d8d000005zejveai-dev-ed.my.salesforce.com",
-                org_domain_url="https://d8d000005zejveai-dev-ed.my.salesforce.com",
+                salesforce_base_url="https://example-base-url.my.salesforce-sites.com",
+                org_domain_url="https://example-domain-url.my.salesforce.com",
             ),
         ),
         sf_function_context=SalesforceFunctionContext(

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -15,9 +15,11 @@ from salesforce_functions.data_api.exceptions import (
     UnexpectedRestApiResponsePayload,
 )
 
+from .utils import WIREMOCK_SERVER_URL
+
 
 def new_data_api() -> DataAPI:
-    return DataAPI("http://localhost:12345", "53.0", "EXAMPLE-TOKEN")
+    return DataAPI(WIREMOCK_SERVER_URL, "53.0", "EXAMPLE-TOKEN")
 
 
 @pytest.mark.requires_wiremock
@@ -228,6 +230,8 @@ async def test_create() -> None:
     data_api = new_data_api()
 
     result = await data_api.create(
+        # This example is also used by `tests/fixtures/data_api`.
+        # pylint: disable-next=duplicate-code
         Record(
             "Movie__c",
             fields={

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,8 @@ from starlette.testclient import TestClient
 from salesforce_functions._internal.app import app
 from salesforce_functions._internal.config import PROJECT_PATH_ENV_VAR
 
+WIREMOCK_SERVER_URL = "http://localhost:12345"
+
 
 def generate_cloud_event_headers(
     include_optional_attributes: bool = True,
@@ -47,9 +49,9 @@ def generate_sf_context(
     include_optional_attributes: bool = True,
 ) -> dict[str, str | dict[str, str]]:
     user_context = {
-        "orgDomainUrl": "https://d8d000005zejveai-dev-ed.my.salesforce.com",
+        "orgDomainUrl": "https://example-domain-url.my.salesforce.com",
         "orgId": "00Dxx0000006IYJ",
-        "salesforceBaseUrl": "https://d8d000005zejveai-dev-ed.my.salesforce.com",
+        "salesforceBaseUrl": "https://example-base-url.my.salesforce-sites.com",
         "userId": "005xx000001X8Uz",
         "username": "user@example.tld",
     }
@@ -62,7 +64,7 @@ def generate_sf_context(
         )
 
     return {
-        "apiVersion": "56.0",
+        "apiVersion": "53.0",
         "payloadVersion": "0.1",
         "userContext": user_context,
     }


### PR DESCRIPTION
All of the existing data API tests are performed using a stand-alone `DataAPI` client, rather than via the pre-configured client provided to functions via `context.org.data_api`.

This new test ensures that:
- the public `context.org.data_api` API exists and exposes the data API as expected
- the client is instantiated correctly in `invoke()`
- the shared `aiohttp` session works correctly in `data_api._execute()` (since that code path is untested in the stand-alone tests, since they intentionally don't pass the optional session).

I have also adjusted the mock `salesforceBaseUrl` and `orgDomainUrl` values to more accurately reflect the difference between them. (The former can be a custom URL that doesn't offer an API endpoint, so the client uses the latter, see GUS-W-11819310 for more info.)

GUS-W-12098049.