### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @heroku/languages

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # Setting a specific user to review at the time the PR is opened, prevents email
+    # notification noise for everyone else in the team alias in the `CODEOWNERS` file,
+    # since our teams have the "Only notify requested team members" option enabled.
+    reviewers:
+      - "edmorley"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "monthly"
+    reviewers:
+      - "edmorley"


### PR DESCRIPTION
For parity with our other repositories.

Also sets myself as the default reviewer for Dependabot PRs, to reduce email notification noise to the rest of the members of the team alias, since our teams have the "Only notify requested team members" option enabled. (This is something we should roll out to our other repositories in the future.)

See:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers
https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team

GUS-W-12073227.