### PR TITLE
Make `Context.org` type be non-optional

### DIFF
--- a/salesforce_functions/context.py
+++ b/salesforce_functions/context.py
@@ -37,5 +37,5 @@ class Org:
 class Context:
     """Information relating to the function and the Salesforce org with which it is associated."""
 
-    org: Org | None
+    org: Org
     """Information about the invoking Salesforce organization and user."""

--- a/tests/fixtures/data_api/main.py
+++ b/tests/fixtures/data_api/main.py
@@ -4,7 +4,6 @@ from salesforce_functions import Context, InvocationEvent, Record
 
 
 async def function(_event: InvocationEvent[Any], context: Context) -> str:
-    assert context.org is not None
     record_id = await context.org.data_api.create(
         Record(
             "Movie__c",


### PR DESCRIPTION
Since:
- it's always set by the runtime
- if any of the Cloud Event fields required to populate `Org` were missing, the Cloud Event parsing would have failed previously
- making it non-optional avoids the assertion/conditional boilerplate in user functions required to keep linting/type-checkers passing.

Should there ever be event types in the future where the org-related metadata in the Cloud Event are missing, that will require multiple other changes regardless, and can be handled via a major version bump of this package.

GUS-W-12110741.