### PR TITLE
Mark `SalesforceRestApiError` as publicly exported too

### DIFF
--- a/salesforce_functions/data_api/exceptions.py
+++ b/salesforce_functions/data_api/exceptions.py
@@ -4,6 +4,7 @@ __all__ = [
     "InnerSalesforceRestApiError",
     "DataApiError",
     "MissingIdFieldError",
+    "SalesforceRestApiError",
     "UnexpectedRestApiResponsePayload",
 ]
 


### PR DESCRIPTION
This was unintentionally omitted in #3.