### PR TITLE
Improve the CLI output for the `serve` and `check` commands

### DIFF
--- a/salesforce_functions/_internal/cli.py
+++ b/salesforce_functions/_internal/cli.py
@@ -93,8 +93,6 @@ def main(args: list[str] | None = None) -> int:
 
 
 def check_function(project_path: Path) -> int:
-    print("Checking function...\n")
-
     try:
         load_function(project_path)
     except LoadFunctionError as e:
@@ -106,6 +104,13 @@ def check_function(project_path: Path) -> int:
 
 
 def start_server(project_path: Path, host: str, port: int, workers: int) -> int:
+    if workers == 1:
+        process_mode = "single process mode"
+    else:
+        process_mode = f"multi-process mode ({workers} worker processes)"
+
+    print(f"Starting {PROGRAM_NAME} v{__version__} in {process_mode}.")
+
     # Propagate CLI args to the ASGI app (uvicorn doesn't support passing custom config directly).
     os.environ[PROJECT_PATH_ENV_VAR] = str(project_path)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,7 +99,7 @@ def test_check_subcommand_valid_function(capsys: CaptureFixture[str]) -> None:
 
     output = capsys.readouterr()
     assert output.err == ""
-    assert output.out == "Checking function...\n\nFunction passed validation\n"
+    assert output.out == "Function passed validation\n"
 
 
 def test_check_subcommand_invalid_function(capsys: CaptureFixture[str]) -> None:
@@ -110,7 +110,7 @@ def test_check_subcommand_invalid_function(capsys: CaptureFixture[str]) -> None:
     assert exit_code == 1
 
     output = capsys.readouterr()
-    assert output.out == "Checking function...\n\n"
+    assert output.out == ""
     assert (
         output.err
         == f"Error: Function failed validation! File not found: {absolute_function_path}\n"
@@ -156,7 +156,7 @@ def test_serve_subcommand_missing_project_path(capsys: CaptureFixture[str]) -> N
     assert "error: the following arguments are required: <project-path>" in output.err
 
 
-def test_serve_subcommand_default_options() -> None:
+def test_serve_subcommand_default_options(capsys: CaptureFixture[str]) -> None:
     project_path = "path/to/function"
     # Still a relative path, but with the path separators adjusted for the current OS.
     normalised_path = str(Path(project_path))
@@ -179,8 +179,15 @@ def test_serve_subcommand_default_options() -> None:
 
     assert PROJECT_PATH_ENV_VAR not in os.environ
 
+    output = capsys.readouterr()
+    assert output.err == ""
+    assert (
+        output.out
+        == f"Starting sf-functions-python v{__version__} in single process mode.\n"
+    )
 
-def test_serve_subcommand_custom_options() -> None:
+
+def test_serve_subcommand_custom_options(capsys: CaptureFixture[str]) -> None:
     project_path = "path/to/function"
     # Still a relative path, but with the path separators adjusted for the current OS.
     normalised_path = str(Path(project_path))
@@ -214,6 +221,13 @@ def test_serve_subcommand_custom_options() -> None:
 
     assert PROJECT_PATH_ENV_VAR not in os.environ
 
+    output = capsys.readouterr()
+    assert output.err == ""
+    assert (
+        output.out
+        == f"Starting sf-functions-python v{__version__} in multi-process mode (5 worker processes).\n"
+    )
+
 
 def test_serve_subcommand_invalid_function(capsys: CaptureFixture[str]) -> None:
     fixture = "tests/fixtures/invalid_function_missing_module"
@@ -232,7 +246,10 @@ def test_serve_subcommand_invalid_function(capsys: CaptureFixture[str]) -> None:
     assert exit_code == 3
 
     output = capsys.readouterr()
-    assert output.out == ""
+    assert (
+        output.out
+        == f"Starting sf-functions-python v{__version__} in single process mode.\n"
+    )
     assert output.err.endswith(
         rf"""
 INFO:     Waiting for application startup.


### PR DESCRIPTION
The `serve` command now outputs the version of the runtime being used, as well as the configuration of the server (currently this is only the number of workers, since other than host/port which are already output by uvicorn, the number of workers is the only other config option).

The `check` command's output has been made more concise, since the "Checking function..." intro was unnecessary (given the command runs instantly).

GUS-W-12094313.
GUS-W-12206626.