### PR TITLE
Fix parsing of query with nested object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "httptools>=0.5.0,<0.6",
     "orjson>=3.8.2,<4",
     "python-dateutil>=2.8.2,<3; python_version < '3.11'",
-    "starlette>=0.22.0,<0.23",
+    "starlette>=0.23.0,<0.24",
     "structlog>=22.2.0,<23",
     "uvicorn>=0.20.0,<0.21",
     "uvloop>=0.17.0,<0.18; sys_platform != 'win32' and sys_platform != 'cygwin'",

--- a/salesforce_functions/data_api/_requests.py
+++ b/salesforce_functions/data_api/_requests.py
@@ -234,7 +234,7 @@ async def _process_records_response(
     raise UnexpectedRestApiResponsePayload()
 
 
-async def _parse_record_query_result(json_body: dict, download_file_fn: DownloadFileFunction) -> RecordQueryResult:
+async def _parse_record_query_result(json_body: dict[str, Any], download_file_fn: DownloadFileFunction) -> RecordQueryResult:
     done: bool = json_body["done"]
     total_size: int = json_body["totalSize"]
     next_records_url: str | None = json_body.get("nextRecordsUrl")
@@ -246,10 +246,10 @@ async def _parse_record_query_result(json_body: dict, download_file_fn: Download
     return RecordQueryResult(done, total_size, records, next_records_url)
 
 
-async def _parse_queried_record(record_json: dict, download_file_fn: DownloadFileFunction) -> QueriedRecord:
+async def _parse_queried_record(record_json: dict[str, Any], download_file_fn: DownloadFileFunction) -> QueriedRecord:
     salesforce_object_type = record_json["attributes"]["type"]
 
-    fields = {}
+    fields: dict[str, bytes | QueriedRecord | Any] = {}
     sub_query_results = {}
     for key, value in record_json.items():
         if key == "attributes":

--- a/salesforce_functions/data_api/_requests.py
+++ b/salesforce_functions/data_api/_requests.py
@@ -235,8 +235,7 @@ async def _process_records_response(
 
 
 async def _parse_record_query_result(
-        json_body: dict[str, Any],
-        download_file_fn: DownloadFileFunction
+    json_body: dict[str, Any], download_file_fn: DownloadFileFunction
 ) -> RecordQueryResult:
     done: bool = json_body["done"]
     total_size: int = json_body["totalSize"]
@@ -249,7 +248,9 @@ async def _parse_record_query_result(
     return RecordQueryResult(done, total_size, records, next_records_url)
 
 
-async def _parse_queried_record(record_json: dict[str, Any], download_file_fn: DownloadFileFunction) -> QueriedRecord:
+async def _parse_queried_record(
+    record_json: dict[str, Any], download_file_fn: DownloadFileFunction
+) -> QueriedRecord:
     salesforce_object_type = record_json["attributes"]["type"]
 
     fields: dict[str, bytes | QueriedRecord | Any] = {}
@@ -262,7 +263,9 @@ async def _parse_queried_record(record_json: dict[str, Any], download_file_fn: D
             if "attributes" in value:
                 fields[key] = await _parse_queried_record(value, download_file_fn)
             else:
-                sub_query_results[key] = await _parse_record_query_result(value, download_file_fn)
+                sub_query_results[key] = await _parse_record_query_result(
+                    value, download_file_fn
+                )
         elif _is_binary_field(salesforce_object_type, key):
             fields[key] = await download_file_fn(value)
         else:

--- a/salesforce_functions/data_api/_requests.py
+++ b/salesforce_functions/data_api/_requests.py
@@ -234,7 +234,10 @@ async def _process_records_response(
     raise UnexpectedRestApiResponsePayload()
 
 
-async def _parse_record_query_result(json_body: dict[str, Any], download_file_fn: DownloadFileFunction) -> RecordQueryResult:
+async def _parse_record_query_result(
+        json_body: dict[str, Any],
+        download_file_fn: DownloadFileFunction
+) -> RecordQueryResult:
     done: bool = json_body["done"]
     total_size: int = json_body["totalSize"]
     next_records_url: str | None = json_body.get("nextRecordsUrl")

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -662,13 +662,8 @@ async def test_query_with_associated_record_results() -> None:
                 type="Account",
                 fields={
                     "Name": "TestAccount5",
-                    "Owner": QueriedRecord(
-                        type="User",
-                        fields={
-                            "Name": "Guy Smiley"
-                        }
-                    )
-                }
+                    "Owner": QueriedRecord(type="User", fields={"Name": "Guy Smiley"}),
+                },
             )
-        ]
+        ],
     )

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -645,3 +645,29 @@ async def test_unit_of_work_single_delete() -> None:
     assert result == {
         ReferenceId("referenceId0"): "a01B0000009gSr9IAE",
     }
+
+@pytest.mark.requires_wiremock
+async def test_query_with_associated_record_results() -> None:
+    data_api = new_data_api()
+
+    result = await data_api.query("SELECT Name, Owner.Name from Account LIMIT 1")
+
+    assert result == RecordQueryResult(
+        done=True,
+        total_size=1,
+        next_records_url=None,
+        records=[
+            QueriedRecord(
+                type="Account",
+                fields={
+                    "Name": "TestAccount5",
+                    "Owner": QueriedRecord(
+                        type="User",
+                        fields={
+                            "Name": "Guy Smiley"
+                        }
+                    )
+                }
+            )
+        ]
+    )

--- a/tests/wiremock/mappings/query-with-associated-data.json
+++ b/tests/wiremock/mappings/query-with-associated-data.json
@@ -1,0 +1,32 @@
+{
+  "id" : "fb30aeaf-08a7-4cbc-b4c0-50fc034c1409",
+  "name" : "services_data_v530_query",
+  "request" : {
+    "urlPath" : "/services/data/v53.0/query",
+    "method" : "GET",
+    "queryParameters": {
+      "q": {
+        "equalTo": "SELECT Name, Owner.Name from Account LIMIT 1"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"totalSize\":1,\"done\":true,\"records\":[{\"attributes\":{\"type\":\"Account\",\"url\":\"/services/data/v53.0/sobjects/Account/001B000001PUvQUIA1\"},\"Name\":\"TestAccount5\",\"Owner\":{\"attributes\":{\"type\":\"User\",\"url\":\"/services/data/v53.0/sobjects/User/005B0000008UC2PIAW\"},\"Name\":\"Guy Smiley\"}}]}",
+    "headers" : {
+      "Date" : "Fri, 02 Dec 2022 18:02:55 GMT",
+      "Set-Cookie" : [ "CookieConsentPolicy=0:1; path=/; expires=Sat, 02-Dec-2023 18:02:55 GMT; Max-Age=31536000", "LSKey-c$CookieConsentPolicy=0:1; path=/; expires=Sat, 02-Dec-2023 18:02:55 GMT; Max-Age=31536000", "BrowserId=jA2SIXJrEe2HE63eO1gD5Q; domain=.salesforce.com; path=/; expires=Sat, 02-Dec-2023 18:02:55 GMT; Max-Age=31536000" ],
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Sforce-Limit-Info" : "api-usage=11/100000",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "fb30aeaf-08a7-4cbc-b4c0-50fc034c1409",
+  "persistent" : true,
+  "insertionIndex" : 3
+}


### PR DESCRIPTION
This modifies the parsing routine of data api queries to correctly parse result sets that include nested `QueriedRecord` data.

[W-12157953](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001FiOtaYAF/view)