### PR TITLE
Enable checking of code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,7 @@ jobs:
         run: pytest --verbosity 2 --color yes
       - name: Run pytest (tests that require WireMock)
         if: runner.os != 'Windows'
-        run: pytest --verbosity 2 --color yes -m requires_wiremock
+        run: pytest --verbosity 2 --color yes -m requires_wiremock --cov-append
+      - name: Check code coverage (non-Windows only)
+        if: runner.os != 'Windows'
+        run: coverage report --show-missing --fail-under=100

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ __pycache__/
 .pytest_cache/
 .venv/
 dist/
+htmlcov/
 tests/wiremock/__files/
 .DS_Store
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ development = [
     "pylint==2.15.8",
     "pytest==7.2.0",
     "pytest-asyncio==0.20.3",
+    "pytest-cov==4.0.0",
 ]
 
 [project.scripts]
@@ -54,6 +55,11 @@ path = "salesforce_functions/__version__.py"
 [tool.black]
 target-version = ['py310', 'py311']
 extend-exclude = "(tests/fixtures/invalid_syntax_error/main.py)"
+
+[tool.coverage.run]
+branch = true
+omit = ["salesforce_functions/__main__.py"]
+source = ["salesforce_functions"]
 
 [tool.mypy]
 exclude = ["^tests/fixtures/invalid_syntax_error/main.py$"]
@@ -92,6 +98,8 @@ output-format = "colorized"
 
 [tool.pytest.ini_options]
 addopts = [
+    "--cov",
+    "--cov-report=term-missing",
     "--import-mode=importlib",
     "--strict-markers",
     "-m not requires_wiremock",

--- a/salesforce_functions/_internal/cli.py
+++ b/salesforce_functions/_internal/cli.py
@@ -86,7 +86,7 @@ def main(args: list[str] | None = None) -> int:
         case "version":
             print(__version__)
             return 0
-        case other:
+        case other:  # pragma: no cover
             # This is only reachable in the case of the parser config being out of sync,
             # since argparse handles the user providing invalid subcommands for us.
             raise NotImplementedError(f"Unhandled subcommand '{other}'")

--- a/salesforce_functions/_internal/cloud_event.py
+++ b/salesforce_functions/_internal/cloud_event.py
@@ -8,7 +8,7 @@ import orjson
 from starlette.datastructures import Headers
 
 if sys.version_info < (3, 11):
-    import dateutil.parser
+    import dateutil.parser  # pragma: no cover
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,9 +160,9 @@ def _parse_event_time(time_string: str | None) -> datetime | None:
         # RFC 3339 format dates, so an external library has to be used instead. This library
         # is not used on newer Pythons to keep dependencies to a minimum.
         if sys.version_info < (3, 11):
-            return dateutil.parser.isoparse(time_string)
+            return dateutil.parser.isoparse(time_string)  # pragma: no cover
 
-        return datetime.fromisoformat(time_string)
+        return datetime.fromisoformat(time_string)  # pragma: no cover
     except (TypeError, ValueError) as e:
         raise CloudEventError(f"Unable to parse event time: {e}") from e
 

--- a/salesforce_functions/data_api/__init__.py
+++ b/salesforce_functions/data_api/__init__.py
@@ -115,7 +115,7 @@ class DataAPI:
         except orjson.JSONDecodeError as e:
             raise UnexpectedRestApiResponsePayload() from e
         finally:
-            if not self._shared_session:
+            if session != self._shared_session:  # pragma: no cover
                 await session.close()
 
         return await rest_api_request.process_response(response.status, json_body)
@@ -130,7 +130,7 @@ class DataAPI:
 
             return await response.read()
         finally:
-            if not self._shared_session:
+            if session != self._shared_session:  # pragma: no cover
                 await session.close()
 
     def _default_headers(self) -> dict[str, str]:

--- a/salesforce_functions/data_api/_requests.py
+++ b/salesforce_functions/data_api/_requests.py
@@ -20,16 +20,16 @@ T = TypeVar("T")
 
 class RestApiRequest(Generic[T]):
     def url(self, org_domain_url: str, api_version: str) -> str:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def http_method(self) -> HttpMethod:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def request_body(self) -> Json | None:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     async def process_response(self, status_code: int, json_body: Json | None) -> T:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 class QueryRecordsRestApiRequest(RestApiRequest[RecordQueryResult]):
@@ -96,7 +96,7 @@ class CreateRecordRestApiRequest(RestApiRequest[str]):
         if isinstance(json_body, dict):
             return str(json_body["id"])
 
-        raise UnexpectedRestApiResponsePayload()
+        raise UnexpectedRestApiResponsePayload()  # pragma: no cover
 
 
 class UpdateRecordRestApiRequest(RestApiRequest[str]):
@@ -123,7 +123,7 @@ class UpdateRecordRestApiRequest(RestApiRequest[str]):
 
     async def process_response(self, status_code: int, json_body: Json | None) -> str:
         if status_code != 204:
-            raise SalesforceRestApiError(_parse_errors(json_body))
+            raise SalesforceRestApiError(_parse_errors(json_body))  # pragma: no cover
 
         return str(self._record.fields["Id"])
 
@@ -193,7 +193,7 @@ class CompositeGraphRestApiRequest(RestApiRequest[dict[ReferenceId, str]]):
         # This is the case when the composite request itself has errors. Errors of the sub-requests are handled
         # separately.
         if status_code != 200:
-            raise SalesforceRestApiError(_parse_errors(json_body))
+            raise SalesforceRestApiError(_parse_errors(json_body))  # pragma: no cover
 
         if isinstance(json_body, dict):
             composite_responses = json_body["graphs"][0]["graphResponse"][
@@ -219,7 +219,7 @@ class CompositeGraphRestApiRequest(RestApiRequest[dict[ReferenceId, str]]):
 
             return result
 
-        raise UnexpectedRestApiResponsePayload()
+        raise UnexpectedRestApiResponsePayload()  # pragma: no cover
 
 
 async def _process_records_response(
@@ -231,7 +231,7 @@ async def _process_records_response(
     if isinstance(json_body, dict):
         return await _parse_record_query_result(json_body, download_file_fn)
 
-    raise UnexpectedRestApiResponsePayload()
+    raise UnexpectedRestApiResponsePayload()  # pragma: no cover
 
 
 async def _parse_record_query_result(
@@ -303,4 +303,4 @@ def _parse_errors(json_errors: Json | None) -> list[InnerSalesforceRestApiError]
             for json_error in json_errors
         ]
 
-    raise UnexpectedRestApiResponsePayload()
+    raise UnexpectedRestApiResponsePayload()  # pragma: no cover


### PR DESCRIPTION
Locally, code coverage checking is enabled, but only prints a summary, and does not enforce a threshold, since the common case of testing locally is with the default pytest options, which intentionally do not run the WireMock-requiring tests, so will not achieve full coverage.

In CI however, code coverage is enforced, and is checked by running pytest twice (once for tests that run on all platforms, and again for the WireMock tests), followed by the `coverage report` command.

The `pytest-cov` pytest plugin is used, which is a thin wrapper around the `coverage` Python package.

In the future additional tests will be added to cover some more of the cases currently marked as `# pragma: no cover`.

See:
https://pytest-cov.readthedocs.io
https://coverage.readthedocs.io

GUS-W-12207644.