### PR TITLE
Adjust CI unit-test step order to prevent intermittent failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,20 +56,20 @@ jobs:
           cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: pip install --disable-pip-version-check --progress-bar off --editable .[development]
-      - name: Run pytest
-        run: pytest --verbosity 2 --color yes
-      - name: Set up Java 11 for WireMock
-        if: matrix.os != 'windows-latest'
+      - name: Set up Java 11 for WireMock (non-Windows only)
+        if: runner.os != 'Windows'
         uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11
-      - name: Download WireMock
-        if: matrix.os != 'windows-latest'
+      - name: Download WireMock (non-Windows only)
+        if: runner.os != 'Windows'
         run: curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --max-time 60 -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/2.35.0/wiremock-jre8-standalone-2.35.0.jar
-      - name: Start WireMock
-        if: matrix.os != 'windows-latest'
+      - name: Start WireMock (non-Windows only)
+        if: runner.os != 'Windows'
         run: java -jar wiremock.jar --root-dir tests/wiremock --port 12345 &
-      - name: Run pytest (Tests marked with requires_wiremock)
-        if: matrix.os != 'windows-latest'
+      - name: Run pytest (tests that work on all platforms)
+        run: pytest --verbosity 2 --color yes
+      - name: Run pytest (tests that require WireMock)
+        if: runner.os != 'Windows'
         run: pytest --verbosity 2 --color yes -m requires_wiremock


### PR DESCRIPTION
I've occasionally seen intermittent failures in CI due to the WireMock server not having fully booted before the WireMock tests run.

By moving the WireMock setup earlier in the CI steps order (such that running the non-WireMock tests occurs between the WireMock setup and the actual WireMock tests being run, it should give more time for the server to start.

In addition, I have:
- Switched to the `runner.os` var as suggested in the docs:
   https://docs.github.com/en/actions/learn-github-actions/environment-variables#detecting-the-operating-system
- Adjusted the step names, so it is clearer why those steps are skipped when looking at a Windows job in the dashboard.

GUS-W-12212543.