### PR TITLE
Test that the version command output can be parsed as semver

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -267,3 +267,10 @@ def test_version_subcommand(capsys: CaptureFixture[str]) -> None:
     output = capsys.readouterr()
     assert output.err == ""
     assert output.out == f"{__version__}\n"
+
+    # Ensure the command output can be parsed as a semver-compatible string by the CLI and CNB.
+    # This test is more restrictive than semver, but that's fine for our purposes, and saves
+    # adding another dependency (which might even be using a different semver flavour anyway).
+    version_parts = output.out.strip().split(".")
+    assert len(version_parts) == 3
+    assert all(map(lambda s: s.isdigit(), version_parts))


### PR DESCRIPTION
The output of the `sf-functions-python version` command is consumed by the CLI (and in the future by the CNB) and parsed as semver, in order to perform the minimum version check.

This test ensure that the output remains parsable like this in the future, and that some other prefix isn't added to the version stdout, or a non-semver version string (like `X.Y`) isn't used.

GUS-W-12207642.