### PR TITLE
Skip code coverage report when tests fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ addopts = [
     "--cov",
     "--cov-report=term-missing",
     "--import-mode=importlib",
+    "--no-cov-on-fail",
     "--strict-markers",
     "-m not requires_wiremock",
 ]


### PR DESCRIPTION
So that the test output is easier to read when tests fail, since the code coverage report is otherwise output right at the end of the log output, requiring scrolling up to see the actual test failures.

GUS-W-12207644.