### PR TITLE
Test the server binds to both the IPv4 and IPv6 localhost adapters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ extend-exclude = "(tests/fixtures/invalid_syntax_error/main.py)"
 
 [tool.coverage.run]
 branch = true
-omit = ["salesforce_functions/__main__.py"]
 source = ["salesforce_functions"]
 
 [tool.mypy]


### PR DESCRIPTION
When developing locally, `sf run function` can end up connecting to either the IPv4 or IPv6 localhost adapter, depending on the host's OS and hosts file. We recently found that when run locally, the Java Function runtime currently only binds to the IPv4 adapter, causing some clients to fail to connect.

Manual testing showed that this did not affect the current Python implementation, however this adds a test that ensures that doesn't change in the future. (Particularly since it's somewhat dependant on an unintentional side-effect of uvicorns's single-worker implementation).

As an added bonus, this test also adds coverage of:
- the `__main__.py` entrypoint (so we can stop skipping it for coverage)
- running the server outside of `starlette`'s `TestClient` (which tries to emulate the ASGI app being run by a server such as uvicorn, but it's still worth testing the real thing).

See also:
https://docs.python.org/3.11/library/subprocess.html#subprocess.Popen

GUS-W-12102191.