### PR TITLE
Add README badges for PyPI and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # sf-functions-python
 
+[![PyPI](https://img.shields.io/pypi/v/salesforce-functions.svg?label=PyPI)](https://pypi.org/project/salesforce-functions/)
+[![CI](https://github.com/heroku/sf-functions-python/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/sf-functions-python/actions/workflows/ci.yml)
+
 Python support for Salesforce Functions.


### PR DESCRIPTION
To make the currently published version more discoverable, and to save a few clicks when I (or anyone else) wants to visit PyPI or CI results.

I was going to also add the shields.io badge for listing the supported Python versions, however that appears to be dependant on the PyPI package `classifiers`, rather than using the newer `requires-python` field. We'll add the classifiers later, but until they are set in the published package, the badge would be broken, so I've not added it here.