### PR TITLE
Add classifiers and keywords to PyPI package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,16 @@ build-backend = "hatchling.build"
 [project]
 name = "salesforce-functions"
 description = "Python support for Salesforce Functions"
+keywords = ["functions", "salesforce"]
 readme = "README.md"
 license = "BSD-3-Clause"
 dynamic = ["version"]
 requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+]
 # httptools and uvloop are optional uvicorn dependencies that improve performance.
 dependencies = [
     "aiohttp>=3.8.3,<4",


### PR DESCRIPTION
Whilst we use the newer `requires-python` field to indicate to Pip which Python versions are supported, some other tools (such as the README badge for supported Python versions) only support reading the Python versions from the classifiers list.

See:
https://peps.python.org/pep-0621/#specification
https://pypi.org/classifiers/

GUS-W-12225669.