### PR TITLE
Add integration testing in CI using the CNB and Salesforce CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,87 @@ jobs:
       - name: Check code coverage (non-Windows only)
         if: runner.os != 'Windows'
         run: coverage report --show-missing --fail-under=100
+
+  # This job tests:
+  # - Building the package as a wheel using Hatch's CLI (otherwise only performed when publishing to PyPI).
+  # - That the package and template function are compatible with the latest Python CNB/builder image.
+  # - Using the package from `site-packages` (the unit tests use editable mode, so run from the source directory).
+  # - Using the package without the development-only dependencies installed (in case there was a mix up).
+  integration-test-buildpack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Pack CLI
+        uses: buildpacks/github-actions/setup-pack@v4.9.0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install Hatch
+        run: pip install hatch
+      - name: Build a wheel for the salesforce-functions package
+        run: hatch build --clean --target wheel
+      - name: Update the template function to use the wheel
+        run: |
+          set -x
+          PACKAGE_VERSION=$(hatch version)
+          WHEEL_FILENAME="salesforce_functions-${PACKAGE_VERSION}-py3-none-any.whl"
+          mv "dist/${WHEEL_FILENAME}" tests/fixtures/template/
+          echo "./${WHEEL_FILENAME}" > tests/fixtures/template/requirements.txt
+      - name: Build the template function using pack
+        run: pack build --builder heroku/builder:22 --path tests/fixtures/template/ template-function
+      - name: Start the template function container
+        run: docker run --name template-function --detach -p 12345:12345 --env PORT=12345 template-function
+      - name: Test the template function's health check response
+        # We're testing via the health check since the template function uses the data API,
+        # so would otherwise require us to mock the Salesforce org using WireMock.
+        run: |
+          if curl --fail --retry 5 --retry-delay 1 --retry-all-errors --connect-timeout 3 -X POST -i -H 'x-health-check: true' http://localhost:12345; then
+            echo "Successful response from function"
+          else
+            echo -e "Function did not respond successfully\n\nContainer logs:\n"
+            docker logs template-function
+            exit 1
+          fi
+
+  # This job tests:
+  # - That the package and template function are compatible with the latest SF CLI's Python local function runner.
+  # - Using the package from `site-packages` (the unit tests use editable mode, so run from the source directory).
+  # - Using the package without the development-only dependencies installed (in case there was a mix up).
+  integration-test-sf-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install SF CLI
+        run: |
+          curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --max-time 60 https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz \
+            | tar -xJC "${HOME}"
+          echo "${HOME}/sfdx/bin" >> "${GITHUB_PATH}"
+      - name: Output SF CLI version
+        run: sf --version
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install the salesforce-functions package and its dependencies
+        run: pip install --disable-pip-version-check --progress-bar off .
+      - name: Start the template function locally
+        run: sf run function start local &> ../server-output.txt &
+        working-directory: tests/fixtures/template/
+      - name: Test the template function's health check response
+        # We're testing via the health check since the template function uses the data API,
+        # so would otherwise require us to mock the Salesforce org using WireMock.
+        run: |
+          if curl --fail --retry 5 --retry-delay 1 --retry-all-errors --connect-timeout 3 -X POST -i -H 'x-health-check: true' http://localhost:8080; then
+            echo "Successful response from function"
+          else
+            echo -e "Function did not respond successfully\n\nServer logs:\n"
+            cat server-output.txt
+            exit 1
+          fi

--- a/tests/fixtures/template/main.py
+++ b/tests/fixtures/template/main.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from salesforce_functions import Context, InvocationEvent, get_logger
+
+# The type of the data payload sent with the invocation event.
+# Change this to a more specific type matching the expected payload for
+# improved IDE auto-completion and linting coverage. For example:
+# `EventPayloadType = dict[str, Any]`
+EventPayloadType = Any
+
+logger = get_logger()
+
+
+# These mypy/pylint annotations do not exist in the upstream template. They are required here since
+# we have strict linting/type-checking enabled for this repository, that would otherwise require
+# `context` to be marked as unused (eg: `_context`) and for an explicit return type to be specified
+# (which could harm the UX of using the template, for those less comfortable with Python types).
+# mypy: disable-error-code=no-untyped-def
+# pylint: disable-next=unused-argument
+async def function(event: InvocationEvent[EventPayloadType], context: Context):
+    """Describe the function here."""
+
+    result = await context.org.data_api.query("SELECT Id, Name FROM Account")
+    logger.info(f"Function successfully queried {result.total_size} account records!")
+
+    return result.records

--- a/tests/fixtures/template/project.toml
+++ b/tests/fixtures/template/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.1"
+id = "{{fnName}}"
+description = "A Salesforce Function"
+type = "function"
+salesforce-api-version = "56.0"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -149,6 +149,19 @@ record_id=12345 invocationId=56ff961b-61b9-4310-a159-1f997221ccfb level=info msg
     assert output.err == ""
 
 
+def test_template_function() -> None:
+    # TODO: Create a WireMock mapping for the template function's data API usage, and make
+    # this test actually invoke the function, rather than just performing a health check.
+    # Or alternatively, stop using the data API in the template function so the template
+    # works out of the box in production without requiring permissions setup.
+    response = invoke_function(
+        "tests/fixtures/template", headers={"x-health-check": "true"}
+    )
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == "OK"
+
+
 def test_invalid_function() -> None:
     expected_message = r"Function failed to load! File not found: .+$"
 

--- a/tests/test_function_loader.py
+++ b/tests/test_function_loader.py
@@ -36,6 +36,11 @@ def test_function_without_type_annotations() -> None:
     load_function(fixture)
 
 
+def test_template_function() -> None:
+    fixture = Path("tests/fixtures/template")
+    load_function(fixture)
+
+
 def test_invalid_function_nonexistent_directory() -> None:
     fixture = Path("this_directory_does_not_exist")
     absolute_function_path = fixture.resolve().joinpath("main.py")


### PR DESCRIPTION
This repository's unit/functional tests are very thorough, however they only test the `sf-functions-python` entry point and everything within it.

These new integration tests ensure the `sf-functions-python` command works as expected when used via the Python CNB or Salesforce CLI, catching potential issues like breaking changes in the subcommand options, mismatched expectations over host/port binding, or whether the runtime works with the CNB's default Python version.

As an added bonus, they also test:
- Building the package as a wheel using Hatch's CLI (which is otherwise only performed when publishing to PyPI).
- Using the package from `site-packages` (the unit tests use editable mode, so run from the source directory).
- Using the package without the development-only dependencies installed (to catch runtime dependencies being added as development-only).
- That a vendored copy of the template function is valid.

See:
https://hatch.pypa.io/latest/cli/reference/#hatch-build
https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm#sfdx_setup_install_cli_linux
https://github.com/heroku/sf-functions-core/tree/main/tmpl/python
https://github.com/heroku/builder/blob/d8fc360dfcba12e54688bfa78fdf82baf5daa931/.github/workflows/build-test-publish.yml#L112-L123

GUS-W-12207663.
GUS-W-12207654.