### PR TITLE
Enable the pylint `useless-suppression` rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ disable = [
     "redefined-outer-name",
     "too-many-instance-attributes",
 ]
+enable = [
+    "useless-suppression",
+]
 
 [tool.pylint.reports]
 output-format = "colorized"


### PR DESCRIPTION
Which will cause it to output (informational only, sadly) messages about any redundant `# pylint: disable ...` annotations in the codebase.

https://pylint.pycqa.org/en/latest/user_guide/messages/information/useless-suppression.html