### PR TITLE
Improve error message wordings shown for invalid functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The error messages shown for invalid functions have been improved.
 
 ## [0.1.0] - 2022-12-14
 

--- a/salesforce_functions/_internal/app.py
+++ b/salesforce_functions/_internal/app.py
@@ -80,7 +80,7 @@ async def invoke(request: Request) -> OrjsonResponse:
     )
 
     try:
-        function_result = await app.state.user_function(event, context)
+        function_result = await app.state.function(event, context)
     except Exception as e:  # pylint: disable=broad-except
         message = (
             f"Exception occurred whilst executing function: {e.__class__.__name__}: {e}"
@@ -119,13 +119,13 @@ async def lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     app.state.logger = get_logger().bind()
 
     try:
-        app.state.user_function = load_function(config.project_path())
+        app.state.function = load_function(config.project_path())
     except LoadFunctionError as e:
         # We cannot log an error message and `sys.exit(1)` like in the CLI's `check_function()`,
         # since we're running inside a uvicorn-managed coroutine. So instead, we raise an
         # exception and suppress the unwanted traceback using `tracebacklimit`.
         sys.tracebacklimit = 0
-        raise RuntimeError(f"Function failed to load! {e}") from None
+        raise RuntimeError(f"Unable to load function: {e}") from None
 
     async with (
         DataAPI._create_session()  # pyright: ignore [reportPrivateUsage] pylint:disable=protected-access

--- a/salesforce_functions/_internal/cli.py
+++ b/salesforce_functions/_internal/cli.py
@@ -96,7 +96,7 @@ def check_function(project_path: Path) -> int:
     try:
         load_function(project_path)
     except LoadFunctionError as e:
-        print(f"Error: Function failed validation! {e}", file=sys.stderr)
+        print(f"Function failed validation: {e}", file=sys.stderr)
         return 1
 
     print("Function passed validation")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -163,11 +163,11 @@ def test_template_function() -> None:
 
 
 def test_invalid_function() -> None:
-    expected_message = r"Function failed to load! File not found: .+$"
+    expected_message = r"Unable to load function: A main.py file was not found at: .+$"
 
     try:
         with pytest.raises(RuntimeError, match=expected_message):
-            invoke_function("tests/fixtures/invalid_function_missing_module")
+            invoke_function("tests/fixtures/invalid_missing_main_py")
 
         # The error handling in `app.lifespan()` sets a custom `sys.tracebacklimit` to
         # truncate the traceback, to improve readability of the error message.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,8 +109,8 @@ def test_check_subcommand_valid_function(capsys: CaptureFixture[str]) -> None:
 
 
 def test_check_subcommand_invalid_function(capsys: CaptureFixture[str]) -> None:
-    fixture = "tests/fixtures/invalid_function_missing_module"
-    absolute_function_path = Path(fixture).resolve().joinpath("main.py")
+    fixture = "tests/fixtures/invalid_missing_main_py"
+    main_py_path = Path(fixture).resolve().joinpath("main.py")
 
     exit_code = main(args=["check", fixture])
     assert exit_code == 1
@@ -119,7 +119,7 @@ def test_check_subcommand_invalid_function(capsys: CaptureFixture[str]) -> None:
     assert output.out == ""
     assert (
         output.err
-        == f"Error: Function failed validation! File not found: {absolute_function_path}\n"
+        == f"Function failed validation: A main.py file was not found at: {main_py_path}\n"
     )
 
 
@@ -270,8 +270,8 @@ def test_serve_subcommand_valid_function() -> None:
 
 
 def test_serve_subcommand_invalid_function(capsys: CaptureFixture[str]) -> None:
-    fixture = "tests/fixtures/invalid_function_missing_module"
-    absolute_function_path = Path(fixture).resolve().joinpath("main.py")
+    fixture = "tests/fixtures/invalid_missing_main_py"
+    main_py_path = Path(fixture).resolve().joinpath("main.py")
 
     try:
         with pytest.raises(SystemExit) as exc_info:
@@ -298,7 +298,7 @@ def test_serve_subcommand_invalid_function(capsys: CaptureFixture[str]) -> None:
     assert output.err.endswith(
         rf"""
 INFO:     Waiting for application startup.
-ERROR:    RuntimeError: Function failed to load! File not found: {absolute_function_path}
+ERROR:    RuntimeError: Unable to load function: A main.py file was not found at: {main_py_path}
 
 ERROR:    Application startup failed. Exiting.
 """

--- a/tests/test_function_loader.py
+++ b/tests/test_function_loader.py
@@ -44,7 +44,9 @@ def test_template_function() -> None:
 def test_invalid_function_nonexistent_directory() -> None:
     fixture = Path("this_directory_does_not_exist")
     absolute_function_path = fixture.resolve().joinpath("main.py")
-    expected_message = rf"File not found: {re.escape(str(absolute_function_path))}$"
+    expected_message = (
+        rf"A main\.py file was not found at: {re.escape(str(absolute_function_path))}$"
+    )
 
     with pytest.raises(LoadFunctionError, match=expected_message):
         load_function(fixture)
@@ -53,7 +55,9 @@ def test_invalid_function_nonexistent_directory() -> None:
 def test_invalid_function_missing_module() -> None:
     fixture = Path("tests/fixtures/invalid_missing_main_py")
     absolute_function_path = fixture.resolve().joinpath("main.py")
-    expected_message = rf"File not found: {re.escape(str(absolute_function_path))}$"
+    expected_message = (
+        rf"A main\.py file was not found at: {re.escape(str(absolute_function_path))}$"
+    )
 
     with pytest.raises(LoadFunctionError, match=expected_message):
         load_function(fixture)
@@ -66,7 +70,7 @@ def test_invalid_function_syntax_error() -> None:
     )
 
     fixture = Path("tests/fixtures/invalid_syntax_error")
-    expected_message = r"""Exception during import:
+    expected_message = r"""Could not import main\.py:
 
 Traceback \(most recent call last\):
 (?s:.+)
@@ -79,8 +83,7 @@ $"""
 
 def test_invalid_function_missing_function() -> None:
     fixture = Path("tests/fixtures/invalid_missing_function")
-    absolute_function_path = fixture.resolve().joinpath("main.py")
-    expected_message = rf"A function named 'function' was not found in: {re.escape(str(absolute_function_path))}$"
+    expected_message = r"A function named 'function' was not found in main\.py\.$"
 
     with pytest.raises(LoadFunctionError, match=expected_message):
         load_function(fixture)
@@ -88,8 +91,7 @@ def test_invalid_function_missing_function() -> None:
 
 def test_invalid_function_not_a_function() -> None:
     fixture = Path("tests/fixtures/invalid_not_a_function")
-    absolute_function_path = fixture.resolve().joinpath("main.py")
-    expected_message = rf"A function named 'function' was not found in: {re.escape(str(absolute_function_path))}$"
+    expected_message = r"A function named 'function' was not found in main\.py\.$"
 
     with pytest.raises(LoadFunctionError, match=expected_message):
         load_function(fixture)
@@ -98,7 +100,7 @@ def test_invalid_function_not_a_function() -> None:
 def test_invalid_function_not_async() -> None:
     fixture = Path("tests/fixtures/invalid_not_async")
     expected_message = (
-        r"The function named 'function' must be an async function\."
+        r"The function named 'function' in main\.py must be an async function\."
         r" Change the function definition from 'def function' to 'async def function'\.$"
     )
 
@@ -108,7 +110,10 @@ def test_invalid_function_not_async() -> None:
 
 def test_invalid_function_number_of_args() -> None:
     fixture = Path("tests/fixtures/invalid_number_of_args")
-    expected_message = r"The function named 'function' has the wrong number of parameters \(expected 2 but found 3\)\.$"
+    expected_message = (
+        r"The function named 'function' in main\.py has the wrong number of parameters"
+        r" \(expected 2 but found 3\)\.$"
+    )
 
     with pytest.raises(LoadFunctionError, match=expected_message):
         load_function(fixture)


### PR DESCRIPTION
This adjusts the error messages shown when a function project contains an invalid function:
- to be clearer
- so that they read well in the context of the CNB running the `check` command
- so that they will be distinguishable from the error messages that will be added in later PRs as part of implementing support for `project.toml` configuration.

GUS-W-12256189.