### PR TITLE
Use coverage-conditional-plugin to reduce `no cover` annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 [project.optional-dependencies]
 development = [
     "black==22.12.0",
+    "coverage-conditional-plugin==0.8.0",
     "flake8==6.0.0",
     "isort[colors]==5.11.4",
     # httpx is required for starlette's `TestClient`.
@@ -64,8 +65,15 @@ path = "salesforce_functions/__version__.py"
 target-version = ['py310', 'py311']
 extend-exclude = "(tests/fixtures/invalid_syntax_error/main.py)"
 
+[tool.coverage.coverage_conditional_plugin.rules]
+# We're using the `no-cover-` rule name prefixes since the default pragma syntax isn't intuitive:
+# https://github.com/wemake-services/coverage-conditional-plugin/issues/188
+no-cover-python-gte-311 = "sys_version_info >= (3, 11)"
+no-cover-python-lt-311 = "sys_version_info < (3, 11)"
+
 [tool.coverage.run]
 branch = true
+plugins = ["coverage_conditional_plugin"]
 source = ["salesforce_functions"]
 
 [tool.mypy]

--- a/salesforce_functions/_internal/cloud_event.py
+++ b/salesforce_functions/_internal/cloud_event.py
@@ -8,7 +8,9 @@ import orjson
 from starlette.datastructures import Headers
 
 if sys.version_info < (3, 11):
-    import dateutil.parser  # pragma: no cover
+    import dateutil.parser  # pragma: no-cover-python-gte-311
+else:
+    pass  # pragma: no-cover-python-lt-311
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,9 +162,11 @@ def _parse_event_time(time_string: str | None) -> datetime | None:
         # RFC 3339 format dates, so an external library has to be used instead. This library
         # is not used on newer Pythons to keep dependencies to a minimum.
         if sys.version_info < (3, 11):
-            return dateutil.parser.isoparse(time_string)  # pragma: no cover
+            return dateutil.parser.isoparse(
+                time_string
+            )  # pragma: no-cover-python-gte-311
 
-        return datetime.fromisoformat(time_string)  # pragma: no cover
+        return datetime.fromisoformat(time_string)  # pragma: no-cover-python-lt-311
     except (TypeError, ValueError) as e:
         raise CloudEventError(f"Unable to parse event time: {e}") from e
 

--- a/salesforce_functions/_internal/config.py
+++ b/salesforce_functions/_internal/config.py
@@ -7,9 +7,9 @@ from typing import Any
 if sys.version_info < (3, 11):
     # `tomllib` was only added to the stdlib in Python 3.11, so for older Python
     # versions we use the third party `tomli` package, which has an identical API.
-    import tomli as tomllib  # pragma: no cover
+    import tomli as tomllib  # pragma: no-cover-python-gte-311
 else:
-    import tomllib  # pragma: no cover
+    import tomllib  # pragma: no-cover-python-lt-311
 
 MINIMUM_SALESFORCE_API_MAJOR_VERSION = 53
 


### PR DESCRIPTION
Previously the `# pragma: no cover` annotation (that tells Coverage.py to ignore missing coverage on that line of code) was being used in cases where we have test coverage, but it's Python version dependant.

The `coverage-conditional-plugin` plugin allows us to only ignore coverage under certain conditions, rather than ignoring it in all environments.

See:
https://github.com/wemake-services/coverage-conditional-plugin

GUS-W-12261444.