### PR TITLE
Add a test for DataAPI's shared session handling

### DIFF
--- a/salesforce_functions/data_api/__init__.py
+++ b/salesforce_functions/data_api/__init__.py
@@ -115,7 +115,7 @@ class DataAPI:
         except orjson.JSONDecodeError as e:
             raise UnexpectedRestApiResponsePayload() from e
         finally:
-            if session != self._shared_session:  # pragma: no cover
+            if session != self._shared_session:
                 await session.close()
 
         return await rest_api_request.process_response(response.status, json_body)
@@ -130,7 +130,7 @@ class DataAPI:
 
             return await response.read()
         finally:
-            if session != self._shared_session:  # pragma: no cover
+            if session != self._shared_session:
                 await session.close()
 
     def _default_headers(self) -> dict[str, str]:


### PR DESCRIPTION
There were previously no tests in `test_data_api.py` that used a shared session, even though a shared session is always used when the data API is initialised by the ASGI app.

Whilst there is a test in `test_app.py` that tests the integration of the data API into the ASGI app (and thus uses a shared session), it only tests:
- the happy path (no request exceptions)
- making a single request (so doesn't test session re-use)
- making a standard query that doesn't involve binary data (so doesn't exercise `DataAPI._download_file()`'s session handling)

The new test tests all of these, allowing the removal of a few more coverage exclusion annotations.

GUS-W-12261661.