### PR TITLE
Add a README badge for supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # sf-functions-python
 
 [![PyPI](https://img.shields.io/pypi/v/salesforce-functions.svg?label=PyPI)](https://pypi.org/project/salesforce-functions/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/salesforce-functions.svg?label=Python)](https://pypi.org/project/salesforce-functions/)
 [![CI](https://github.com/heroku/sf-functions-python/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/sf-functions-python/actions/workflows/ci.yml)
 
 Python support for [Salesforce Functions](https://developer.salesforce.com/docs/platform/functions/overview).


### PR DESCRIPTION
It uses the Python versions specified in the PyPI classifiers of the most recently published version.