### PR TITLE
Validate type annotations using pyright too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         run: pylint salesforce_functions/ tests/
       - name: Run mypy
         run: mypy
+      - name: Run pyright
+        run: npx --package=pyright@latest -- pyright --warnings
+      - name: Run pyright in verify exported types mode
+        run: npx --package=pyright@latest -- pyright --ignoreexternal --verifytypes salesforce_functions
       - name: Run Black
         run: black --check --diff --color .
       - name: Run isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,12 @@ enable = [
 [tool.pylint.reports]
 output-format = "colorized"
 
+[tool.pyright]
+exclude = ["tests/fixtures/invalid_syntax_error/main.py"]
+include = ["salesforce_functions", "tests"]
+pythonPlatform = "All"
+typeCheckingMode = "strict"
+
 [tool.pytest.ini_options]
 addopts = [
     "--cov",

--- a/salesforce_functions/data_api/_requests.py
+++ b/salesforce_functions/data_api/_requests.py
@@ -1,5 +1,5 @@
 from base64 import standard_b64encode
-from typing import Any, Awaitable, Callable, Generic, Literal, TypeVar
+from typing import Any, Awaitable, Callable, Generic, Literal, TypeVar, cast
 from urllib.parse import urlencode
 
 from .exceptions import (
@@ -260,6 +260,7 @@ async def _parse_queried_record(
             continue
 
         if isinstance(value, dict):
+            value = cast(dict[str, Any], value)
             if "attributes" in value:
                 fields[key] = await _parse_queried_record(value, download_file_fn)
             else:


### PR DESCRIPTION
We already validate the Python type annotations using mypy, however VSCode's Python integration uses the more-strict alternative type-checker pyright.

This has meant on a few occasions type failures only show up in my IDE and not in CI. (As demonstrated by the types that needed fixing as part of this PR.)

To prevent this, we now run pyright in CI. It is run in both the standard full-codebase type checking mode, as well as a mode that verifies the type-completeness of our publicly exported types (which checks the types from a consumer's point of view).

We still run mypy, since many consumers of this package may still be using mypy, so we need to ensure our exported type annotations keep both type checkers satisfied.

https://github.com/microsoft/pyright#installation
https://github.com/microsoft/pyright/blob/main/docs/configuration.md
https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#verifying-type-completeness

GUS-W-12291199.