### PR TITLE
Switch to keyword-only arguments for `DataAPI` and all dataclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- All publicly exported `dataclass`es (such as `Context`, `InvocationEvent` and `Record`) now only accept their fields being passed as keyword arguments, rather than as positional arguments.
 
 ## [0.2.0] - 2022-12-22
 

--- a/salesforce_functions/_internal/app.py
+++ b/salesforce_functions/_internal/app.py
@@ -69,9 +69,9 @@ async def invoke(request: Request) -> OrjsonResponse:
             base_url=cloudevent.sf_context.user_context.salesforce_base_url,
             domain_url=cloudevent.sf_context.user_context.org_domain_url,
             data_api=DataAPI(
-                cloudevent.sf_context.user_context.org_domain_url,
-                app.state.salesforce_api_version,
-                cloudevent.sf_function_context.access_token,
+                org_domain_url=cloudevent.sf_context.user_context.org_domain_url,
+                api_version=request.app.state.salesforce_api_version,
+                access_token=cloudevent.sf_function_context.access_token,
                 session=request.app.state.data_api_session,
             ),
             user=User(
@@ -83,7 +83,7 @@ async def invoke(request: Request) -> OrjsonResponse:
     )
 
     try:
-        function_result = await app.state.function(event, context)
+        function_result = await request.app.state.function(event, context)
     except Exception as e:  # pylint: disable=broad-except
         message = (
             f"Exception occurred whilst executing function: {e.__class__.__name__}: {e}"

--- a/salesforce_functions/_internal/cloud_event.py
+++ b/salesforce_functions/_internal/cloud_event.py
@@ -13,7 +13,7 @@ else:
     pass  # pragma: no-cover-python-lt-311
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class SalesforceUserContext:
     org_id: str
     user_id: str
@@ -24,7 +24,7 @@ class SalesforceUserContext:
     org_domain_url: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class SalesforceContext:
     api_version: str
     payload_version: str
@@ -61,7 +61,7 @@ class SalesforceContext:
             raise CloudEventError(f"sfcontext missing required key {e}") from e
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class SalesforceFunctionContext:
     # TODO: Figure out discrepancy with schema: https://github.com/forcedotcom/sf-fx-schema/issues/8
     access_token: str
@@ -99,7 +99,7 @@ class SalesforceFunctionContext:
             raise CloudEventError(f"sffncontext missing required key {e}") from e
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class SalesforceFunctionsCloudEvent:
     id: str
     source: str

--- a/salesforce_functions/context.py
+++ b/salesforce_functions/context.py
@@ -5,7 +5,7 @@ from .data_api import DataAPI
 __all__ = ["User", "Org", "Context"]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class User:
     """Information about the invoking Salesforce user."""
 
@@ -17,7 +17,7 @@ class User:
     """The ID of the user on whose behalf this user is operating."""
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Org:
     """Information about the invoking Salesforce organization and user."""
 
@@ -33,7 +33,7 @@ class Org:
     """The currently logged in user."""
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Context:
     """Information relating to the function and the Salesforce org with which it is associated."""
 

--- a/salesforce_functions/data_api/__init__.py
+++ b/salesforce_functions/data_api/__init__.py
@@ -29,6 +29,7 @@ class DataAPI:
 
     def __init__(
         self,
+        *,
         org_domain_url: str,
         api_version: str,
         access_token: str,
@@ -49,7 +50,12 @@ class DataAPI:
     async def query_more(self, result: RecordQueryResult) -> RecordQueryResult:
         """Query for more records, based on the given `RecordQueryResult`."""
         if result.next_records_url is None:
-            return RecordQueryResult(True, result.total_size, [], None)
+            return RecordQueryResult(
+                done=True,
+                total_size=result.total_size,
+                records=[],
+                next_records_url=None,
+            )
 
         return await self._execute(
             QueryNextRecordsRestApiRequest(result.next_records_url, self._download_file)

--- a/salesforce_functions/data_api/exceptions.py
+++ b/salesforce_functions/data_api/exceptions.py
@@ -9,7 +9,7 @@ __all__ = [
 ]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class InnerSalesforceRestApiError:
     """An error returned from the Salesforce REST API."""
 
@@ -22,18 +22,18 @@ class DataApiError(Exception):
     """Base class for Data API exceptions"""
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class SalesforceRestApiError(DataApiError):
     """Raised when the Salesforce REST API signalled error(s)."""
 
     api_errors: list[InnerSalesforceRestApiError]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class MissingIdFieldError(DataApiError):
     """Raised when the given Record must contain an "Id" field, but none was found."""
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class UnexpectedRestApiResponsePayload(DataApiError):
     """Raised when the Salesforce REST API returned an unexpected payload."""

--- a/salesforce_functions/data_api/record.py
+++ b/salesforce_functions/data_api/record.py
@@ -4,7 +4,7 @@ from typing import Any
 __all__ = ["Record", "QueriedRecord", "RecordQueryResult"]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Record:
     """A Salesforce record."""
 
@@ -14,7 +14,7 @@ class Record:
     """The fields belonging to the record."""
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class QueriedRecord(Record):
     """
     A Salesforce record that has been queried.
@@ -27,7 +27,7 @@ class QueriedRecord(Record):
     """Additional query results from sub queries."""
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class RecordQueryResult:
     """The result of a record query."""
 

--- a/salesforce_functions/data_api/reference_id.py
+++ b/salesforce_functions/data_api/reference_id.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 __all__ = ["ReferenceId"]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ReferenceId:
     """
     A reference id for an operation inside a unit of work.

--- a/salesforce_functions/data_api/unit_of_work.py
+++ b/salesforce_functions/data_api/unit_of_work.py
@@ -46,7 +46,7 @@ class UnitOfWork:
         return self._register(DeleteRecordRestApiRequest(object_type, record_id))
 
     def _register(self, request: RestApiRequest[str]) -> ReferenceId:
-        reference_id = ReferenceId("referenceId" + str(self._next_reference_id))
+        reference_id = ReferenceId(id="referenceId" + str(self._next_reference_id))
         self._next_reference_id += 1
 
         self._sub_requests[reference_id] = request

--- a/salesforce_functions/invocation_event.py
+++ b/salesforce_functions/invocation_event.py
@@ -7,7 +7,7 @@ __all__ = ["InvocationEvent"]
 T = TypeVar("T")
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class InvocationEvent(Generic[T]):
     """The metadata and data payload of the event that caused the function to be invoked."""
 

--- a/tests/fixtures/data_api/main.py
+++ b/tests/fixtures/data_api/main.py
@@ -6,7 +6,7 @@ from salesforce_functions import Context, InvocationEvent, Record
 async def function(_event: InvocationEvent[Any], context: Context) -> str:
     record_id = await context.org.data_api.create(
         Record(
-            "Movie__c",
+            type="Movie__c",
             fields={
                 "Name": "Star Wars Episode V: The Empire Strikes Back",
                 "Rating__c": "Excellent",


### PR DESCRIPTION
In order to reduce the chance of errors at the call-sites, and make them self-documenting.

See:
https://peps.python.org/pep-3102/
https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass

GUS-W-12291595.