### PR TITLE
Cleanup structlog configuration

### DIFF
--- a/salesforce_functions/_internal/logging.py
+++ b/salesforce_functions/_internal/logging.py
@@ -5,18 +5,27 @@ import structlog
 
 
 def configure_logging() -> None:
+    """
+    Configure structlog to output logs in logfmt format, using options recommended for best performance.
+
+    https://www.brandur.org/logfmt
+    https://www.structlog.org/en/stable/performance.html
+    """
     structlog.configure(
         processors=[
+            # Adds any log attributes bound to the request context (such as `invocationId`).
             structlog.contextvars.merge_contextvars,
+            # Adds the log event level as `level={info,warning,...}`.
             structlog.processors.add_log_level,
+            # Override the default structlog message key name of `event`.
             structlog.processors.EventRenamer("msg"),
-            structlog.processors.ExceptionRenderer(),
-            # TODO: Only apply the pretty printer in development?
+            # Pretty print any exceptions prior to the logfmt log line referencing the exception.
+            # The output is not in logfmt style, but makes the exception much easier to read than
+            # trying to newline escape it and output it under an attribute on the log line itself.
             structlog.processors.ExceptionPrettyPrinter(),
             structlog.processors.LogfmtRenderer(),
-            # TODO: Use console renderer instead in development?
-            # structlog.dev.ConsoleRenderer(),
         ],
+        # Only output log level info and above.
         wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
         logger_factory=structlog.WriteLoggerFactory(),
         cache_logger_on_first_use=True,


### PR DESCRIPTION
* Remove TODO comments (since I've now investigated alternative logging approaches for development, and prefer the current configuration).
* Remove the redundant `ExceptionRenderer` (since `ExceptionPrettyPrinter` already handles formatting exceptions if `ExceptionRenderer` wasn't used prior).
* Add some general comments explaining the config.

GUS-W-11870937.