### PR TITLE
Clean up function exception handling

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from unittest.mock import patch
 
@@ -244,11 +245,16 @@ def test_function_raises_exception_at_runtime(capsys: CaptureFixture[str]) -> No
     assert response.json() == expected_message
 
     output = capsys.readouterr()
-    assert output.out.endswith(
-        rf"""
+    assert re.fullmatch(
+        rf"""Traceback \(most recent call last\):
+  File ".+app.py", line \d+, in handle_function_invocation
+    function_result = await function\(event, context\)
+  .+
 ZeroDivisionError: division by zero
 invocationId=56ff961b-61b9-4310-a159-1f997221ccfb level=error msg="{expected_message}"
-"""
+""",
+        output.out,
+        flags=re.DOTALL,
     )
     assert output.err == ""
 


### PR DESCRIPTION
* Prevents the `request.app.state` reference from appearing in the stack trace.
* The explicitly added `Function` type also improves type checking of `app.py` since `request.app.state` always returns the `Any` type.
* Adds a test for the output, which confirms the output doesn't include lots of irrelevant frames (eg those from uvicorn or starlette)
* Renames `invoke` to something more self-documenting (mainly for our benefit, though it also does appear in the user stack trace).

Before:

```
Traceback (most recent call last):
  File "/Users/emorley/src/sf-functions-python/salesforce_functions/_internal/app.py", line 86, in invoke
    function_result = await request.app.state.function(event, context)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/emorley/src/sf-functions-python/tests/fixtures/raises_exception_at_runtime/main.py", line 5, in function
    return 1 / 0
           ~~^~~
ZeroDivisionError: division by zero
```

After:

```
Traceback (most recent call last):
  File "/Users/emorley/src/sf-functions-python/salesforce_functions/_internal/app.py", line 88, in handle_function_invocation
    function_result = await function(event, context)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/emorley/src/sf-functions-python/tests/fixtures/raises_exception_at_runtime/main.py", line 5, in function
    return 1 / 0
           ~~^~~
ZeroDivisionError: division by zero
```

GUS-W-12304372.