### PR TITLE
Output the stack trace if an unhandled internal error occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - All publicly exported `dataclass`es (such as `Context`, `InvocationEvent` and `Record`) now only accept their fields being passed as keyword arguments, rather than as positional arguments.
+- If an unhandled internal runtime error occurs, the log output now includes the full stack trace.
 
 ## [0.2.0] - 2022-12-22
 

--- a/salesforce_functions/_internal/app.py
+++ b/salesforce_functions/_internal/app.py
@@ -104,8 +104,9 @@ async def handle_function_invocation(request: Request) -> OrjsonResponse:
 
 
 async def handle_internal_error(request: Request, e: Exception) -> OrjsonResponse:
+    logger: BoundLogger = request.app.state.logger
     message = f"Internal error: {e.__class__.__name__}: {e}"
-    request.app.state.logger.error(message)
+    logger.exception(message)
     return OrjsonResponse(message, status_code=500)
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -290,7 +290,15 @@ def test_internal_error(capsys: CaptureFixture[str]) -> None:
     assert response.json() == expected_message
 
     output = capsys.readouterr()
-    assert output.out == f'level=error msg="{expected_message}"\n'
+    assert re.fullmatch(
+        rf"""Traceback \(most recent call last\):
+  .+
+ValueError: Some internal error
+level=error msg="{expected_message}"
+""",
+        output.out,
+        flags=re.DOTALL,
+    )
     assert output.err == ""
 
 


### PR DESCRIPTION
Previously only the exception name and string representation would be shown in the case of an unhandled internal runtime error occurring. Now the full stack trace is output too.

GUS-W-12304403.