### PR TITLE
Remove support for skipping check-changelog using the PR description

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -2,7 +2,7 @@ name: Check Changelog
 
 on:
   pull_request:
-    types: [opened, reopened, edited, labeled, unlabeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -10,11 +10,7 @@ permissions:
 jobs:
   check-changelog:
     runs-on: ubuntu-22.04
-    if: |
-      !contains(github.event.pull_request.body, '[skip changelog]') &&
-      !contains(github.event.pull_request.body, '[changelog skip]') &&
-      !contains(github.event.pull_request.body, '[skip ci]') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip changelog')
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Since:
- We only ever use the `skip changelog` label method of skipping the check.
- Supporting skip-comments in the PR description means the check has to listen to the `edited` event type, which causes action-churn every time a PR description is edited, eg, see:  https://github.com/heroku/sf-functions-python/actions/workflows/check_changelog.yml
- Having a clear single way to skip the check seems preferable to a grab-bag of approaches.