### PR TITLE
Bump the minimum dependency versions to their latest releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - All publicly exported `dataclass`es (such as `Context`, `InvocationEvent` and `Record`) now only accept their fields being passed as keyword arguments, rather than as positional arguments.
 - If an unhandled internal runtime error occurs, the log output now includes the full stack trace.
+- The minimum version of the dependencies `orjson`, `starlette` and `structlog` have been raised.
 
 ## [0.2.0] - 2022-12-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,10 @@ classifiers = [
 dependencies = [
     "aiohttp>=3.8.3,<4",
     "httptools>=0.5.0,<0.6",
-    "orjson>=3.8.2,<4",
+    "orjson>=3.8.4,<4",
     "python-dateutil>=2.8.2,<3; python_version < '3.11'",
-    "starlette>=0.23.0,<0.24",
-    "structlog>=22.2.0,<23",
+    "starlette>=0.23.1,<0.24",
+    "structlog>=22.3.0,<23",
     "tomli>=2.0.1,<3; python_version < '3.11'",
     "uvicorn>=0.20.0,<0.21",
     "uvloop>=0.17.0,<0.18; sys_platform != 'win32' and sys_platform != 'cygwin'",


### PR DESCRIPTION
To ensure the latest fixes are picked up by end users, and that at least for now, the versions used match those we test in CI (which will pull in the latest version in the version range).

GUS-W-12120409.