### PR TITLE
Add tests for `__main__.py` and the entry point script

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 import sys
-from importlib.metadata import distribution
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -12,20 +11,7 @@ from pytest import CaptureFixture
 
 from salesforce_functions.__version__ import __version__
 from salesforce_functions._internal.app import PROJECT_PATH_ENV_VAR
-from salesforce_functions._internal.cli import (
-    ASGI_APP_IMPORT_STRING,
-    PROGRAM_NAME,
-    main,
-)
-
-
-def test_program_name_matches_package_entry_points() -> None:
-    package_script_names = (
-        distribution("salesforce_functions")
-        .entry_points.select(group="console_scripts")
-        .names
-    )
-    assert PROGRAM_NAME in package_script_names
+from salesforce_functions._internal.cli import ASGI_APP_IMPORT_STRING, main
 
 
 def test_base_help(capsys: CaptureFixture[str]) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,45 @@
+import subprocess
+
+import pytest
+
+from salesforce_functions._internal.cli import PROGRAM_NAME
+
+
+def test_package_main() -> None:
+    process = subprocess.run(
+        ["python", "-m", "salesforce_functions", "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert process.returncode == 0
+    assert process.stderr == ""
+    assert "usage: sf-functions-python" in process.stdout
+
+
+def test_package_main_non_zero_exit_code() -> None:
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        subprocess.run(
+            ["python", "-m", "salesforce_functions"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    assert exc_info.value.returncode == 2
+    assert (
+        "error: the following arguments are required: subcommand"
+        in exc_info.value.stderr
+    )
+
+
+def test_entry_point_script() -> None:
+    """Tests the `sf-functions-python` entry point that is used by the CLI and CNB."""
+    process = subprocess.run(
+        [PROGRAM_NAME, "--help"], check=True, capture_output=True, text=True
+    )
+
+    assert process.returncode == 0
+    assert process.stderr == ""
+    assert "usage: sf-functions-python" in process.stdout


### PR DESCRIPTION
The two ways the Python function runtime's CLI can be started are:
1. Via the `sf-functions-python` script, which is created on package installation thanks to the entry points feature ([docs](https://packaging.python.org/en/latest/specifications/entry-points/)).
2. `python -m salesforce_functions`, which works due to our inclusion of a [`__main__.py`](https://github.com/heroku/sf-functions-python/blob/main/salesforce_functions/__main__.py) file ([docs](https://docs.python.org/3/library/__main__.html#main-py-in-python-packages)).

Whilst both were implicitly tested elsewhere (`-m salesforce_functions` [in one of the CLI tests](https://github.com/heroku/sf-functions-python/blob/bf72379985529f112cdb8ed9bad5a18a80201c06/tests/test_cli.py#L257-L258) due to needing to launch a subprocess; and `sf-functions-python` via the [CI-only integration tests](https://github.com/heroku/sf-functions-python/blob/bf72379985529f112cdb8ed9bad5a18a80201c06/.github/workflows/ci.yml#L84-L166)), we should have explicit pytest-based tests for them, given they are a public interface.

GUS-W-12334786.