### PR TITLE
Make all module-internal functions private

### DIFF
--- a/salesforce_functions/_internal/cli.py
+++ b/salesforce_functions/_internal/cli.py
@@ -76,9 +76,9 @@ def main(args: list[str] | None = None) -> int:
 
     match parsed_args.subcommand:
         case "check":
-            return check_function(parsed_args.project_path)
+            return _check_function(parsed_args.project_path)
         case "serve":
-            return start_server(
+            return _start_server(
                 parsed_args.project_path,
                 parsed_args.host,
                 parsed_args.port,
@@ -93,7 +93,7 @@ def main(args: list[str] | None = None) -> int:
             raise NotImplementedError(f"Unhandled subcommand '{other}'")
 
 
-def check_function(project_path: Path) -> int:
+def _check_function(project_path: Path) -> int:
     try:
         load_config(project_path)
         load_function(project_path)
@@ -105,7 +105,7 @@ def check_function(project_path: Path) -> int:
     return 0
 
 
-def start_server(project_path: Path, host: str, port: int, workers: int) -> int:
+def _start_server(project_path: Path, host: str, port: int, workers: int) -> int:
     if workers == 1:
         process_mode = "single process mode"
     else:

--- a/salesforce_functions/_internal/cloud_event.py
+++ b/salesforce_functions/_internal/cloud_event.py
@@ -33,7 +33,7 @@ class SalesforceContext:
     @classmethod
     def from_base64_json(cls, base64_json: str) -> "SalesforceContext":
         try:
-            data = parse_base64_json(base64_json)
+            data = _parse_base64_json(base64_json)
         except (binascii.Error, UnicodeDecodeError) as e:
             raise CloudEventError(f"sfcontext is not correctly encoded: {e}") from e
         except orjson.JSONDecodeError as e:
@@ -75,7 +75,7 @@ class SalesforceFunctionContext:
     @classmethod
     def from_base64_json(cls, base64_json: str) -> "SalesforceFunctionContext":
         try:
-            data = parse_base64_json(base64_json)
+            data = _parse_base64_json(base64_json)
         except (binascii.Error, UnicodeDecodeError) as e:
             raise CloudEventError(f"sffncontext is not correctly encoded: {e}") from e
         except orjson.JSONDecodeError as e:
@@ -149,7 +149,7 @@ class SalesforceFunctionsCloudEvent:
             raise CloudEventError(f"Missing required header {e}") from e
 
 
-def parse_base64_json(base64_json: str) -> Any:
+def _parse_base64_json(base64_json: str) -> Any:
     return orjson.loads(binascii.a2b_base64(base64_json))
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -171,7 +171,7 @@ def test_invalid_config() -> None:
         with pytest.raises(RuntimeError, match=expected_message):
             invoke_function("tests/fixtures/project_toml_file_missing")
 
-        # The error handling in `app.lifespan()` sets a custom `sys.tracebacklimit` to
+        # The error handling in `app._lifespan()` sets a custom `sys.tracebacklimit` to
         # truncate the traceback, to improve readability of the error message.
         assert getattr(sys, "tracebacklimit", None) == 0
     finally:
@@ -189,7 +189,7 @@ def test_invalid_function() -> None:
         with pytest.raises(RuntimeError, match=expected_message):
             invoke_function("tests/fixtures/invalid_missing_main_py")
 
-        # The error handling in `app.lifespan()` sets a custom `sys.tracebacklimit` to
+        # The error handling in `app._lifespan()` sets a custom `sys.tracebacklimit` to
         # truncate the traceback, to improve readability of the error message.
         assert getattr(sys, "tracebacklimit", None) == 0
     finally:
@@ -247,7 +247,7 @@ def test_function_raises_exception_at_runtime(capsys: CaptureFixture[str]) -> No
     output = capsys.readouterr()
     assert re.fullmatch(
         rf"""Traceback \(most recent call last\):
-  File ".+app.py", line \d+, in handle_function_invocation
+  File ".+app.py", line \d+, in _handle_function_invocation
     function_result = await function\(event, context\)
   .+
 ZeroDivisionError: division by zero

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -278,7 +278,7 @@ def test_serve_subcommand_invalid_config(capsys: CaptureFixture[str]) -> None:
         with pytest.raises(SystemExit) as exc_info:
             main(args=["serve", fixture])
 
-        # The error handling in `app.lifespan()` sets a custom `sys.tracebacklimit` to
+        # The error handling in `app._lifespan()` sets a custom `sys.tracebacklimit` to
         # truncate the traceback, to improve readability of the error message.
         assert getattr(sys, "tracebacklimit", None) == 0
     finally:
@@ -314,7 +314,7 @@ def test_serve_subcommand_invalid_function(capsys: CaptureFixture[str]) -> None:
         with pytest.raises(SystemExit) as exc_info:
             main(args=["serve", fixture])
 
-        # The error handling in `app.lifespan()` sets a custom `sys.tracebacklimit` to
+        # The error handling in `app._lifespan()` sets a custom `sys.tracebacklimit` to
         # truncate the traceback, to improve readability of the error message.
         assert getattr(sys, "tracebacklimit", None) == 0
     finally:


### PR DESCRIPTION
Whilst all of these functions are descendants of the `_internal` module (and so already private), the documentation linters I was trying out do not recognise this, which causes false positives.

Renaming these functions to be private both avoids the above, and makes it clearer when looking at these modules that the functions are not only not publicly exported, but are also only meant for usage within that single file (and not within other internal modules under `_internal.*`).

GUS-W-12366695.