### PR TITLE
Refactor `get_logger`

### DIFF
--- a/salesforce_functions/_internal/app.py
+++ b/salesforce_functions/_internal/app.py
@@ -119,10 +119,7 @@ async def lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     requests, and anything after will be run when the server shuts down.
     """
     configure_logging()
-    # `get_logger()` returns a proxy that only instantiates the logger on first usage.
-    # Calling `bind()` here ensures that this instantiation doesn't have to occur each
-    # time the function is invoked.
-    app.state.logger = get_logger().bind()
+    app.state.logger = get_logger()
 
     # This env var is set by the CLI, as a way to propagate CLI args to the ASGI app.
     project_path = Path(os.environ[PROJECT_PATH_ENV_VAR])

--- a/salesforce_functions/_internal/logging.py
+++ b/salesforce_functions/_internal/logging.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Callable
 
 import structlog
 
@@ -32,4 +31,15 @@ def configure_logging() -> None:
     )
 
 
-get_logger: Callable[..., structlog.stdlib.BoundLogger] = structlog.stdlib.get_logger
+def get_logger() -> structlog.stdlib.BoundLogger:
+    """
+    Create a logger instance that outputs logs in logfmt style.
+
+    The logger's API matches the stdlib's `logger.Logger`, however the output
+    will be in the structured `logfmt` logging style.
+    """
+    # structlog's `get_logger()` returns a proxy that only instantiates the logger on first usage.
+    # Calling `bind()` here ensures that this instantiation doesn't have to occur each time a
+    # the function is invoked. `configure_logging()` must be called (by us) prior to `get_logger()`
+    # being used for the first time.
+    return structlog.stdlib.get_logger().bind()


### PR DESCRIPTION
The publicly exported `get_logger()` is now a function we define, rather than a simple re-export of `structlog.stdlib.get_logger`.

This allows us to:
- Override structlog's docstring (which was previously not very helpful when one didn't know the context of structlog)
- Call `.bind()` before passing the logger back, which means the logger is already instantiated, rather than being a lazy proxy that is only instantiated on first use (which can impact performance depending on how the consumer uses it).

GUS-W-12366719.