### PR TITLE
Move private static methods out of `DataAPI`

### DIFF
--- a/salesforce_functions/_internal/app.py
+++ b/salesforce_functions/_internal/app.py
@@ -13,7 +13,7 @@ from starlette.routing import Route
 from structlog.stdlib import BoundLogger
 
 from ..context import Context, Org, User
-from ..data_api import DataAPI
+from ..data_api import DataAPI, _create_session  # pyright: ignore [reportPrivateUsage]
 from ..invocation_event import InvocationEvent
 from .cloud_event import CloudEventError, SalesforceFunctionsCloudEvent
 from .config import ConfigError, load_config
@@ -136,9 +136,7 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
 
     app.state.salesforce_api_version = config.salesforce_api_version
 
-    async with (
-        DataAPI._create_session()  # pyright: ignore [reportPrivateUsage] pylint:disable=protected-access
-    ) as data_api_session:
+    async with _create_session() as data_api_session:
         app.state.data_api_session = data_api_session
         yield
 

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -10,6 +10,9 @@ from salesforce_functions import (
     ReferenceId,
     UnitOfWork,
 )
+from salesforce_functions.data_api import (
+    _create_session,  # pyright: ignore [reportPrivateUsage]
+)
 from salesforce_functions.data_api import DataAPI
 from salesforce_functions.data_api.exceptions import (
     InnerSalesforceRestApiError,
@@ -693,9 +696,7 @@ async def test_session() -> None:
     after each request (including when requests fail). The query used is one that returns binary
     data, to ensure that the session handling in `DataAPI._download_file()` is exercised too.
     """
-    async with (
-        DataAPI._create_session()  # pyright: ignore [reportPrivateUsage] pylint:disable=protected-access
-    ) as session:
+    async with _create_session() as session:
         data_api = new_data_api(session=session)
 
         first_result = await data_api.query(


### PR DESCRIPTION
Since:
- being static, they don't actually use `DataAPI`
- we expose `DataAPI` to end users, and whilst these methods were private, they can still be used unless end projects have linting set up to prevent it
- some of the docs linting tools don't handle private static methods well

GUS-W-12384800.