### PR TITLE
Improve docstrings for public APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - All publicly exported `dataclass`es (such as `Context`, `InvocationEvent` and `Record`) now only accept their fields being passed as keyword arguments, rather than as positional arguments.
 - If an unhandled internal runtime error occurs, the log output now includes the full stack trace.
+- The docstrings for several public types and APIs have been improved.
 - The minimum version of the dependencies `orjson`, `starlette` and `structlog` have been raised.
 
 ## [0.2.0] - 2022-12-22

--- a/salesforce_functions/_internal/logging.py
+++ b/salesforce_functions/_internal/logging.py
@@ -37,6 +37,21 @@ def get_logger() -> structlog.stdlib.BoundLogger:
 
     The logger's API matches the stdlib's `logger.Logger`, however the output
     will be in the structured `logfmt` logging style.
+
+    Example:
+
+    ```python
+    from salesforce_functions import get_logger
+
+    logger = get_logger()
+
+    async def function(event: InvocationEvent[Any], context: Context):
+        logger.info("Info message")
+        logger.warning("Warning message")
+        logger.error("Error message")
+
+        logger.info("Info message with an additional structured log attribute", record_id=12345)
+    ```
     """
     # structlog's `get_logger()` returns a proxy that only instantiates the logger on first usage.
     # Calling `bind()` here ensures that this instantiation doesn't have to occur each time a

--- a/salesforce_functions/data_api/__init__.py
+++ b/salesforce_functions/data_api/__init__.py
@@ -25,7 +25,11 @@ T = TypeVar("T")
 
 
 class DataAPI:
-    """Data API client to interact with data in a Salesforce org."""
+    """
+    Data API client to interact with data in a Salesforce org.
+
+    A preconfigured instance of this client is provided at `Context.org.data_api`.
+    """
 
     def __init__(
         self,
@@ -74,7 +78,7 @@ class DataAPI:
         return await self._execute(UpdateRecordRestApiRequest(record))
 
     async def delete(self, object_type: str, record_id: str) -> str:
-        """Deletes an existing record of the given type and id."""
+        """Delete an existing record of the given type and id."""
         return await self._execute(DeleteRecordRestApiRequest(object_type, record_id))
 
     async def commit_unit_of_work(

--- a/salesforce_functions/data_api/exceptions.py
+++ b/salesforce_functions/data_api/exceptions.py
@@ -19,7 +19,7 @@ class InnerSalesforceRestApiError:
 
 
 class DataApiError(Exception):
-    """Base class for Data API exceptions"""
+    """Base class for Data API exceptions."""
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -31,7 +31,7 @@ class SalesforceRestApiError(DataApiError):
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class MissingIdFieldError(DataApiError):
-    """Raised when the given Record must contain an "Id" field, but none was found."""
+    """Raised when the given Record must contain an `Id` field, but none was found."""
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/salesforce_functions/data_api/record.py
+++ b/salesforce_functions/data_api/record.py
@@ -19,7 +19,7 @@ class QueriedRecord(Record):
     """
     A Salesforce record that has been queried.
 
-    Extends Record with potential sub query results that can only exist when
+    Extends `Record` with potential sub query results that can only exist when
     a record was queried from the data API.
     """
 

--- a/salesforce_functions/data_api/reference_id.py
+++ b/salesforce_functions/data_api/reference_id.py
@@ -6,7 +6,7 @@ __all__ = ["ReferenceId"]
 @dataclass(frozen=True, kw_only=True, slots=True)
 class ReferenceId:
     """
-    A reference id for an operation inside a unit of work.
+    A reference id for an operation inside a `UnitOfWork`.
 
     Used to reference results of other operations inside the same unit of work.
     """

--- a/salesforce_functions/data_api/unit_of_work.py
+++ b/salesforce_functions/data_api/unit_of_work.py
@@ -12,9 +12,9 @@ __all__ = ["UnitOfWork"]
 
 class UnitOfWork:
     """
-    Represents a UnitOfWork.
+    Represents a `UnitOfWork`.
 
-    After registering all operations, it can be submitted via the commit_unit_of_work method of DataApi.
+    After registering all operations, it can be submitted via the `commit_unit_of_work` method of `DataAPI`.
     """
 
     def __init__(self) -> None:
@@ -23,25 +23,28 @@ class UnitOfWork:
 
     def register_create(self, record: Record) -> ReferenceId:
         """
-        Register a record creation for the UnitOfWork.
+        Register a record creation for the `UnitOfWork`.
 
-        Returns a ReferenceId that can be used to refer to the created record in subsequent operations in this
-        UnitOfWork.
+        Returns a `ReferenceId` that can be used to refer to the created record in subsequent operations in this
+        `UnitOfWork`.
         """
         return self._register(CreateRecordRestApiRequest(record))
 
     def register_update(self, record: Record) -> ReferenceId:
         """
-        Register a record update for the UnitOfWork.
+        Register a record update for the `UnitOfWork`.
 
-        Returns a ReferenceId that can be used to refer to the updated record in subsequent operations in this
-        UnitOfWork.
+        Returns a `ReferenceId` that can be used to refer to the updated record in subsequent operations in this
+        `UnitOfWork`.
         """
         return self._register(UpdateRecordRestApiRequest(record))
 
     def register_delete(self, object_type: str, record_id: str) -> ReferenceId:
         """
         Register a deletion of an existing record of the given type and id.
+
+        Returns a `ReferenceId` that can be used to refer to the updated record in subsequent operations in this
+        `UnitOfWork`.
         """
         return self._register(DeleteRecordRestApiRequest(object_type, record_id))
 

--- a/salesforce_functions/invocation_event.py
+++ b/salesforce_functions/invocation_event.py
@@ -9,7 +9,36 @@ T = TypeVar("T")
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class InvocationEvent(Generic[T]):
-    """The metadata and data payload of the event that caused the function to be invoked."""
+    """
+    The metadata and data payload of the event that caused the function to be invoked.
+
+    The `InvocationEvent` type accepts a single generic parameter, which represents
+    the type of the input data payload present in the `data` field.
+
+    To improve IDE auto-completion and linting coverage, it's recommended to pass an
+    explicit type in the type definition that represents the data payload the function
+    expects to receive.
+
+    For example, if your function needs to accept JSON input like:
+
+    ```json
+    {
+      "fieldOne": "Hello World!",
+      "fieldTwo": 23
+    }
+    ```
+
+    You might wish to use the following Python type annotations:
+
+    ```python
+    EventPayloadType = dict[str, Any]
+
+    async def function(event: InvocationEvent[EventPayloadType], context: Context):
+        # ...
+    ```
+
+    For more information, see the [Python typing documentation](https://docs.python.org/3/library/typing.html).
+    """
 
     id: str
     """The unique identifier for this execution of the function."""
@@ -23,7 +52,18 @@ class InvocationEvent(Generic[T]):
     organization publishing the event or the process that produced the event.
     """
     data: T
-    """The payload of the event."""
+    """
+    The input data payload of the event.
+
+    The type of this field is determined from the generic type parameter passed
+    to `InvocationEvent`.
+
+    For example, `data` will be of type `dict[str, Any]` if the invocation event type is defined as:
+
+    ```python
+    InvocationEvent[dict[str, Any]]
+    ```
+    """
     time: datetime | None
     """
     The timestamp of when the occurrence happened.


### PR DESCRIPTION
The docstrings will be used to generate the API reference docs, and are also shown by IDE Python integrations - so I've had another pass through them to make some improvements.

GUS-W-12384800.