### PR TITLE
Set the `x-extra-info` header on the function HTTP response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - All publicly exported `dataclass`es (such as `Context`, `InvocationEvent` and `Record`) now only accept their fields being passed as keyword arguments, rather than as positional arguments.
-- If an unhandled internal runtime error occurs, the log output now includes the full stack trace.
+- If an unhandled internal runtime error occurs, the log output now includes the full stack trace,
+  and the function response's HTTP status code is now `503` rather than `500`.
+- Invocation metadata is now set on the function response via the `x-extra-info` header.
 - The docstrings for several public types and APIs have been improved.
 - The minimum version of the dependencies `orjson`, `starlette` and `structlog` have been raised.
 


### PR DESCRIPTION
Adds an `x-extra-info` metadata header to the function HTTP responses, in accordance with the functions spec.

See:
https://github.com/forcedotcom/sf-fx-schema/blob/80f5d7e3fa17f216e8b264b4fcb590136eed3f3e/schema.json#L139-L179
https://salesforce.quip.com/b11BA6yXtuNr#dMbACAM3CVE

And Java/Node.js implementations:
https://github.com/forcedotcom/sf-fx-runtime-nodejs/blob/f63accbd99166b0ee350aeb12eb2fd43494aa4d5/src/server.ts#L238-L252
https://github.com/forcedotcom/sf-fx-runtime-nodejs/blob/f63accbd99166b0ee350aeb12eb2fd43494aa4d5/src/server.ts#L98-L103
https://github.com/forcedotcom/sf-fx-runtime-java/blob/main/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/ExtraInfo.java
https://github.com/forcedotcom/sf-fx-runtime-java/blob/e51a238e0b658a656f2b4a2c6fa8d70f2d3a404e/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/UndertowInvocationInterface.java#L148-L265

GUS-W-11790242.