### PR TITLE
Update CloudEvent fixtures to more closely match production

### DIFF
--- a/invoke.sh
+++ b/invoke.sh
@@ -8,18 +8,20 @@ function base64_encode() {
   python3 -c "import base64, sys; print(base64.b64encode(sys.stdin.buffer.read()).decode('ascii'))"
 }
 
-invocation_id="00Dxx0000006IYJEA2-4Y4W3Lw_LkoskcHdEaZze--MyFunction-$(openssl rand -hex 12)"
+invocation_id="00DJS0000000123ABC-$(openssl rand -hex 16)"
 
 sfcontext=$(base64_encode <<'EOF'
 {
-  "apiVersion": "53.0",
+  "apiVersion": "56.0",
   "payloadVersion": "0.1",
   "userContext": {
-    "orgId": "00Dxx0000006IYJ",
-    "userId": "005xx000001X8Uz",
-    "username": "user@example.tld",
+    "onBehalfOfUserId": null,
+    "orgDomainUrl": "https://example-domain-url.my.salesforce.com",
+    "orgId": "00DJS0000000123ABC",
     "salesforceBaseUrl": "https://example-base-url.my.salesforce-sites.com",
-    "orgDomainUrl": "https://example-domain-url.my.salesforce.com"
+    "salesforceInstance": "swe1",
+    "userId": "005JS000000H123",
+    "username": "user@example.tld"
   }
 }
 EOF
@@ -28,7 +30,12 @@ EOF
 sffncontext=$(base64_encode <<EOF
 {
   "accessToken": "EXAMPLE-TOKEN",
-  "requestId": "${invocation_id}"
+  "apexFQN": "ExampleClass:example_function():7",
+  "deadline": "2023-01-19T10:11:12.468085Z",
+  "functionName": "ExampleProject.examplefunction",
+  "invokingNamespace": "",
+  "requestId": "${invocation_id}",
+  "resource": "https://examplefunction-cod-mni.crag-123abc.evergreen.space"
 }
 EOF
 )
@@ -37,11 +44,13 @@ curl "${1:?Provide function runtime url as the first argument to this script!}" 
   -i \
   --connect-timeout 3 \
   -d "${2:?Provide the payload as the second argument to this script!}" \
-  -H "Content-Type: application/json" \
+  -H "content-type: application/json" \
   -H "ce-id: ${invocation_id}" \
-  -H "ce-source: urn:event:from:salesforce/xx/228.0/00Dxx0000006IYJ/apex/MyFunctionApex:test():7" \
+  -H "ce-source: urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7" \
   -H "ce-specversion: 1.0" \
+  -H "ce-time: 2023-01-19T10:09:12.476684Z" \
   -H "ce-type: com.salesforce.function.invoke.sync" \
   -H "ce-sfcontext: ${sfcontext}" \
   -H "ce-sffncontext: ${sffncontext}" \
+  -H "x-request-id: ${invocation_id}" \
   # -H "x-health-check: true" \

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -49,8 +49,8 @@ def test_empty_payload_and_response(capsys: CaptureFixture[str]) -> None:
     extra_info: dict[str, Any] = orjson.loads(response.headers["x-extra-info"])
     exec_time_ms: int = extra_info.pop("execTimeMs")
     assert extra_info == {
-        "requestId": "56ff961b-61b9-4310-a159-1f997221ccfb",
-        "source": "urn:event:from:salesforce/xx/228.0/00Dxx0000006IYJ/apex/MyFunctionApex:test():7",
+        "requestId": "00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179",
+        "source": "urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
         "statusCode": 200,
     }
     assert 0 <= exec_time_ms < 1000
@@ -67,9 +67,9 @@ def test_event_attributes() -> None:
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
         "data": payload,
-        "id": "56ff961b-61b9-4310-a159-1f997221ccfb",
-        "source": "urn:event:from:salesforce/xx/228.0/00Dxx0000006IYJ/apex/MyFunctionApex:test():7",
-        "time": "2022-11-01T12:30:10.123456+00:00",
+        "id": "00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179",
+        "source": "urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
+        "time": "2023-01-19T10:09:12.476684+00:00",
         "type": "com.salesforce.function.invoke.sync",
     }
 
@@ -83,8 +83,8 @@ def test_minimal_event_attributes() -> None:
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
         "data": None,
-        "id": "56ff961b-61b9-4310-a159-1f997221ccfb",
-        "source": "urn:event:from:salesforce/xx/228.0/00Dxx0000006IYJ/apex/MyFunctionApex:test():7",
+        "id": "00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179",
+        "source": "urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
         "time": None,
         "type": "com.salesforce.function.invoke.sync",
     }
@@ -100,10 +100,10 @@ def test_context_attributes() -> None:
             "base_url": "https://example-base-url.my.salesforce-sites.com",
             "data_api": "REMOVED",
             "domain_url": "https://example-domain-url.my.salesforce.com",
-            "id": "00Dxx0000006IYJ",
+            "id": "00DJS0000000123ABC",
             "user": {
-                "id": "005xx000001X8Uz",
-                "on_behalf_of_user_id": "another-user@example.tld",
+                "id": "005JS000000H123",
+                "on_behalf_of_user_id": "005JS000000H456",
                 "username": "user@example.tld",
             },
         },
@@ -122,9 +122,9 @@ def test_minimal_context_attributes() -> None:
             "base_url": "https://example-base-url.my.salesforce-sites.com",
             "data_api": "REMOVED",
             "domain_url": "https://example-domain-url.my.salesforce.com",
-            "id": "00Dxx0000006IYJ",
+            "id": "00DJS0000000123ABC",
             "user": {
-                "id": "005xx000001X8Uz",
+                "id": "005JS000000H123",
                 "on_behalf_of_user_id": None,
                 "username": "user@example.tld",
             },
@@ -157,12 +157,12 @@ def test_logging(capsys: CaptureFixture[str]) -> None:
     assert (
         output.out
         == """Print works but output isn't structured
-invocationId=56ff961b-61b9-4310-a159-1f997221ccfb level=info msg="Info message"
-invocationId=56ff961b-61b9-4310-a159-1f997221ccfb level=warning msg="Warning message"
-invocationId=56ff961b-61b9-4310-a159-1f997221ccfb level=error msg="Error message"
-invocationId=56ff961b-61b9-4310-a159-1f997221ccfb level=critical msg="Critical message"
-record_id=12345 invocationId=56ff961b-61b9-4310-a159-1f997221ccfb level=info msg="Info message with custom metadata"
-"""
+invocationId=00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179 level=info msg="Info message"
+invocationId=00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179 level=warning msg="Warning message"
+invocationId=00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179 level=error msg="Error message"
+invocationId=00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179 level=critical msg="Critical message"
+record_id=12345 invocationId=00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179 level=info msg="Info message with custom metadata"
+"""  # noqa: E501
     )
     assert output.err == ""
 
@@ -301,8 +301,8 @@ def test_function_raises_exception_at_runtime(capsys: CaptureFixture[str]) -> No
     stack: str = extra_info.pop("stack")
     assert extra_info == {
         "isFunctionError": True,
-        "requestId": "56ff961b-61b9-4310-a159-1f997221ccfb",
-        "source": "urn:event:from:salesforce/xx/228.0/00Dxx0000006IYJ/apex/MyFunctionApex:test():7",
+        "requestId": "00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179",
+        "source": "urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
         "statusCode": 500,
     }
     assert 0 <= exec_time_ms < 1000
@@ -324,7 +324,7 @@ ZeroDivisionError: division by zero
     function_result = await function\(event, context\)
   .+
 ZeroDivisionError: division by zero
-invocationId=56ff961b-61b9-4310-a159-1f997221ccfb level=error msg="{expected_message}"
+invocationId=00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179 level=error msg="{expected_message}"
 """,
         output.out,
         flags=re.DOTALL,
@@ -345,8 +345,8 @@ def test_return_value_not_serializable(capsys: CaptureFixture[str]) -> None:
     stack: str = extra_info.pop("stack")
     assert extra_info == {
         "isFunctionError": True,
-        "requestId": "56ff961b-61b9-4310-a159-1f997221ccfb",
-        "source": "urn:event:from:salesforce/xx/228.0/00Dxx0000006IYJ/apex/MyFunctionApex:test():7",
+        "requestId": "00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179",
+        "source": "urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
         "statusCode": 500,
     }
     assert 0 <= exec_time_ms < 1000
@@ -362,7 +362,7 @@ TypeError: Type is not JSON serializable: set
     output = capsys.readouterr()
     assert (
         output.out
-        == f'invocationId=56ff961b-61b9-4310-a159-1f997221ccfb level=error msg="{expected_message}"\n'
+        == f'invocationId=00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179 level=error msg="{expected_message}"\n'
     )
     assert output.err == ""
 

--- a/tests/test_cloud_event.py
+++ b/tests/test_cloud_event.py
@@ -28,22 +28,22 @@ def test_cloud_event() -> None:
     cloud_event = SalesforceFunctionsCloudEvent.from_http(Headers(headers), body)
 
     assert cloud_event == SalesforceFunctionsCloudEvent(
-        id="56ff961b-61b9-4310-a159-1f997221ccfb",
-        source="urn:event:from:salesforce/xx/228.0/00Dxx0000006IYJ/apex/MyFunctionApex:test():7",
+        id="00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179",
+        source="urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
         spec_version="1.0",
         type="com.salesforce.function.invoke.sync",
         data={"record_id": 123},
         data_content_type="application/json",
         data_schema="dataschema TODO",
         subject="subject TODO",
-        time=datetime(2022, 11, 1, 12, 30, 10, 123456, tzinfo=timezone.utc),
+        time=datetime(2023, 1, 19, 10, 9, 12, 476684, tzinfo=timezone.utc),
         sf_context=SalesforceContext(
-            api_version="53.0",
+            api_version="56.0",
             payload_version="0.1",
             user_context=SalesforceUserContext(
-                org_id="00Dxx0000006IYJ",
-                user_id="005xx000001X8Uz",
-                on_behalf_of_user_id="another-user@example.tld",
+                org_id="00DJS0000000123ABC",
+                user_id="005JS000000H123",
+                on_behalf_of_user_id="005JS000000H456",
                 username="user@example.tld",
                 salesforce_base_url="https://example-base-url.my.salesforce-sites.com",
                 org_domain_url="https://example-domain-url.my.salesforce.com",
@@ -51,12 +51,12 @@ def test_cloud_event() -> None:
         ),
         sf_function_context=SalesforceFunctionContext(
             access_token="EXAMPLE-TOKEN",
-            request_id="56ff961b-61b9-4310-a159-1f997221ccfb",
+            request_id="00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179",
             function_invocation_id="functionInvocationId TODO",
-            function_name="MyFunction",
+            function_name="ExampleProject.examplefunction",
             apex_id="apexId TODO",
-            apex_fqn="apexFQN TODO",
-            resource="http://example.com:8080",
+            apex_fqn="ExampleClass:example_function():7",
+            resource="https://examplefunction-cod-mni.crag-123abc.evergreen.space",
         ),
     )
 
@@ -67,8 +67,8 @@ def test_minimal_cloud_event() -> None:
     cloud_event = SalesforceFunctionsCloudEvent.from_http(Headers(headers), body)
 
     assert cloud_event == SalesforceFunctionsCloudEvent(
-        id="56ff961b-61b9-4310-a159-1f997221ccfb",
-        source="urn:event:from:salesforce/xx/228.0/00Dxx0000006IYJ/apex/MyFunctionApex:test():7",
+        id="00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179",
+        source="urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
         spec_version="1.0",
         type="com.salesforce.function.invoke.sync",
         data=None,
@@ -77,11 +77,11 @@ def test_minimal_cloud_event() -> None:
         subject=None,
         time=None,
         sf_context=SalesforceContext(
-            api_version="53.0",
+            api_version="56.0",
             payload_version="0.1",
             user_context=SalesforceUserContext(
-                org_id="00Dxx0000006IYJ",
-                user_id="005xx000001X8Uz",
+                org_id="00DJS0000000123ABC",
+                user_id="005JS000000H123",
                 on_behalf_of_user_id=None,
                 username="user@example.tld",
                 salesforce_base_url="https://example-base-url.my.salesforce-sites.com",
@@ -90,7 +90,7 @@ def test_minimal_cloud_event() -> None:
         ),
         sf_function_context=SalesforceFunctionContext(
             access_token="EXAMPLE-TOKEN",
-            request_id="56ff961b-61b9-4310-a159-1f997221ccfb",
+            request_id="00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179",
             function_invocation_id=None,
             function_name=None,
             apex_id=None,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,11 +15,11 @@ WIREMOCK_SERVER_URL = "http://localhost:12345"
 def generate_cloud_event_headers(
     include_optional_attributes: bool = True,
 ) -> dict[str, str]:
-    invocation_id = "56ff961b-61b9-4310-a159-1f997221ccfb"
+    invocation_id = "00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179"
     headers = {
         "Content-Type": "application/json",
         "ce-id": invocation_id,
-        "ce-source": "urn:event:from:salesforce/xx/228.0/00Dxx0000006IYJ/apex/MyFunctionApex:test():7",
+        "ce-source": "urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
         "ce-specversion": "1.0",
         "ce-type": "com.salesforce.function.invoke.sync",
         "ce-sfcontext": encode_cloud_event_extension(
@@ -30,6 +30,7 @@ def generate_cloud_event_headers(
                 invocation_id, include_optional_attributes=include_optional_attributes
             )
         ),
+        "x-request-id": invocation_id,
     }
 
     if include_optional_attributes:
@@ -37,7 +38,7 @@ def generate_cloud_event_headers(
             {
                 "ce-dataschema": "dataschema TODO",
                 "ce-subject": "subject TODO",
-                "ce-time": "2022-11-01T12:30:10.123456Z",
+                "ce-time": "2023-01-19T10:09:12.476684Z",
             }
         )
 
@@ -48,22 +49,23 @@ def generate_sf_context(
     include_optional_attributes: bool = True,
 ) -> dict[str, str | dict[str, str]]:
     user_context = {
+        "orgId": "00DJS0000000123ABC",
         "orgDomainUrl": "https://example-domain-url.my.salesforce.com",
-        "orgId": "00Dxx0000006IYJ",
         "salesforceBaseUrl": "https://example-base-url.my.salesforce-sites.com",
-        "userId": "005xx000001X8Uz",
+        "salesforceInstance": "swe1",
+        "userId": "005JS000000H123",
         "username": "user@example.tld",
     }
 
     if include_optional_attributes:
         user_context.update(
             {
-                "onBehalfOfUserId": "another-user@example.tld",
+                "onBehalfOfUserId": "005JS000000H456",
             }
         )
 
     return {
-        "apiVersion": "53.0",
+        "apiVersion": "56.0",
         "payloadVersion": "0.1",
         "userContext": user_context,
     }
@@ -80,11 +82,13 @@ def generate_sf_function_context(
     if include_optional_attributes:
         sf_function_context.update(
             {
-                "apexFQN": "apexFQN TODO",
+                "apexFQN": "ExampleClass:example_function():7",
                 "apexId": "apexId TODO",
+                "deadline": "2023-01-19T10:11:12.468085Z",
                 "functionInvocationId": "functionInvocationId TODO",
-                "functionName": "MyFunction",
-                "resource": "http://example.com:8080",
+                "functionName": "ExampleProject.examplefunction",
+                "invokingNamespace": "",
+                "resource": "https://examplefunction-cod-mni.crag-123abc.evergreen.space",
             }
         )
 


### PR DESCRIPTION
There are example CloudEvents used in our unit tests and also the development helper script `invoke.sh`, however their contents was incomplete and slightly out of date.

I dumped the contents of a CloudEvent in production (by using a modified version of the runtime package), and have used that to update the CloudEvent fixtures.

GUS-W-11879536.