### PR TITLE
Add code examples to docstrings for public APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add example code snippets and attribute values to the docstrings for public APIs.
 
 ## [0.3.0] - 2023-01-17
 

--- a/salesforce_functions/context.py
+++ b/salesforce_functions/context.py
@@ -10,23 +10,47 @@ class User:
     """Information about the invoking Salesforce user."""
 
     id: str
-    """The user's ID."""
+    """
+    The user's ID.
+
+    For example: `005JS000000H123`
+    """
     username: str
-    """The name of the user."""
+    """
+    The username of the user.
+
+    For example: `user@example.tld`
+    """
     on_behalf_of_user_id: str | None
-    """The ID of the user on whose behalf this user is operating."""
+    """
+    The ID of the user on whose behalf this user is operating.
+
+    For example: `005JS000000H456`
+    """
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class Org:
-    """Information about the invoking Salesforce organization and user."""
+    """Information about the invoking Salesforce org and user."""
 
     id: str
-    """The Salesforce organization ID."""
+    """
+    The Salesforce org ID.
+
+    For example: `00DJS0000000123ABC`
+    """
     base_url: str
-    """The base URL of the Salesforce organization."""
+    """
+    The base URL of the Salesforce org.
+
+    For example: `https://example-base-url.my.salesforce-sites.com`
+    """
     domain_url: str
-    """The domain URL of the Salesforce organization."""
+    """
+    The domain URL of the Salesforce org.
+
+    For example: `https://example-domain-url.my.salesforce.com`
+    """
     data_api: DataAPI
     """An initialized data API client instance for interacting with data in the org."""
     user: User
@@ -38,4 +62,4 @@ class Context:
     """Information relating to the function and the Salesforce org with which it is associated."""
 
     org: Org
-    """Information about the invoking Salesforce organization and user."""
+    """Information about the invoking Salesforce org and user."""

--- a/salesforce_functions/data_api/record.py
+++ b/salesforce_functions/data_api/record.py
@@ -9,7 +9,11 @@ class Record:
     """A Salesforce record."""
 
     type: str
-    """The Salesforce Object type."""
+    """
+    The Salesforce Object type.
+
+    For example: `Account`
+    """
     fields: dict[str, Any]
     """The fields belonging to the record."""
 

--- a/salesforce_functions/invocation_event.py
+++ b/salesforce_functions/invocation_event.py
@@ -19,7 +19,7 @@ class InvocationEvent(Generic[T]):
     explicit type in the type definition that represents the data payload the function
     expects to receive.
 
-    For example, if your function needs to accept JSON input like:
+    For example, if your function must accept JSON input like:
 
     ```json
     {
@@ -28,7 +28,7 @@ class InvocationEvent(Generic[T]):
     }
     ```
 
-    You might wish to use the following Python type annotations:
+    You can use the following Python type annotations:
 
     ```python
     EventPayloadType = dict[str, Any]
@@ -41,15 +41,25 @@ class InvocationEvent(Generic[T]):
     """
 
     id: str
-    """The unique identifier for this execution of the function."""
+    """
+    The unique identifier for this execution of the function.
+
+    For example: `00DJS0000000123ABC-d75b3b6ece5011dcabbed4-3c6f7179`
+    """
     type: str
-    """The type of this invocation event."""
+    """
+    The type of this invocation event.
+
+    For example: `com.salesforce.function.invoke.sync`
+    """
     source: str
     """
     A URI which identifies the context in which an event happened.
 
     Often this will include information such as the type of the event source, the
-    organization publishing the event or the process that produced the event.
+    org publishing the event or the process that produced the event.
+
+    For example: `urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7`
     """
     data: T
     """


### PR DESCRIPTION
So that examples are shown in both the IDE tooltips and also the auto-generated docs on `developer.salesforce.com`.

The changes here will be synced with the WIP branch on the docs repository after merge.

GUS-W-12406389.