### PR TITLE
Add a public `testing` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add example code snippets and attribute values to the docstrings for public APIs.
+- Add a `testing` module, containing `mock_event` and `mock_context` functions for simplifying unit testing of Python functions.
 
 ## [0.3.0] - 2023-01-17
 

--- a/salesforce_functions/testing.py
+++ b/salesforce_functions/testing.py
@@ -1,0 +1,117 @@
+"""
+Testing utilities for Python Salesforce Functions.
+
+An example Python function unit test:
+
+```python
+from unittest.mock import patch
+
+import pytest
+from salesforce_functions import QueriedRecord, RecordQueryResult
+from salesforce_functions.testing import mock_context, mock_event
+
+from main import function
+
+
+@pytest.mark.asyncio
+async def test_function():
+    event = mock_event(data=None)
+    context = mock_context()
+
+    with patch.object(context.org.data_api, "query") as mock_query:
+        mock_query.return_value = RecordQueryResult(
+            done=True,
+            total_size=1,
+            records=[
+                QueriedRecord(type="Account", fields={"Name": "Example Account"}),
+            ],
+            next_records_url=None,
+        )
+        result = await function(event, context)
+
+    assert result == [
+        QueriedRecord(type="Account", fields={"Name": "Example Account"}),
+    ]
+```
+"""
+
+from datetime import datetime
+from typing import TypeVar
+from uuid import uuid4
+
+from salesforce_functions import Context, InvocationEvent, Org, User
+from salesforce_functions.data_api import DataAPI
+
+T = TypeVar("T")
+
+
+def mock_event(
+    *,
+    data: T,
+    id: str = str(uuid4()),  # pylint: disable=redefined-builtin
+    type: str = "com.salesforce.function.invoke.sync",  # pylint: disable=redefined-builtin
+    source: str = "urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
+    time: datetime = datetime.today(),
+) -> InvocationEvent[T]:
+    """
+    Create an example `InvocationEvent` instance for use in unit tests.
+
+    The `data` parameter is required, and is the input data payload of the event.
+
+    For example:
+
+    ```python
+    event = mock_event(data={"customer_id": "1234"})
+
+    result = await function(event, context)
+    ```
+    """
+    return InvocationEvent(
+        id=id,
+        type=type,
+        source=source,
+        data=data,
+        time=time,
+    )
+
+
+def mock_context(
+    *,
+    org_id: str = "00DJS0000000123ABC",
+    org_domain_url: str = "https://example-domain-url.my.salesforce.tld",
+    user_id: str = "005JS000000H123",
+    username: str = "user@example.tld",
+    on_behalf_of_user_id: str = "005JS000000H456",
+    client_api_version: str = "56.0",
+) -> Context:
+    """
+    Create an example `Context` instance for use in unit tests.
+
+    For example:
+
+    ```python
+    context = mock_context()
+
+    result = await function(event, context)
+    ```
+
+    If the function uses `context.org.data_api`, it will need patching separately,
+    inside the unit test (see the `testing` module overview for more information).
+    """
+    return Context(
+        org=Org(
+            id=org_id,
+            base_url=org_domain_url,
+            domain_url=org_domain_url,
+            data_api=DataAPI(
+                org_domain_url=org_domain_url,
+                api_version=client_api_version,
+                access_token="EXAMPLE-TOKEN",
+            ),
+            user=User(
+                id=user_id,
+                username=username,
+                on_behalf_of_user_id=on_behalf_of_user_id,
+            ),
+        )
+    )

--- a/tests/fixtures/template/tests/test_main.py
+++ b/tests/fixtures/template/tests/test_main.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+import pytest
+
+from salesforce_functions import QueriedRecord, RecordQueryResult
+from salesforce_functions.testing import mock_context, mock_event
+
+# In the upstream template this import has to be an absolute import. However,
+# for the testcase to work in this repository it must be a relative import.
+from ..main import function
+
+
+@pytest.mark.asyncio
+async def test_function() -> None:
+    event = mock_event(data=None)
+    context = mock_context()
+
+    with patch.object(context.org.data_api, "query") as mock_query:
+        mock_query.return_value = RecordQueryResult(
+            done=True,
+            total_size=1,
+            records=[
+                QueriedRecord(type="Account", fields={"Name": "Example Account"}),
+            ],
+            next_records_url=None,
+        )
+        result = await function(event, context)
+
+    assert result == [
+        QueriedRecord(type="Account", fields={"Name": "Example Account"}),
+    ]


### PR DESCRIPTION
That contains utilities to help end users test their Python functions.

The changes to the template function fixture will be upstreamed into the actual template in `sf-functions-core` after this merges.

For functions unit testing prior art, see:
https://github.com/heroku/sf-functions-core/blob/main/tmpl/typescript/test/index.test.ts https://github.com/heroku/sf-functions-core/blob/main/tmpl/java/src/test/java/com/example/FunctionTest.java

For more about pytest/pytest-asyncio, see:
https://docs.pytest.org
https://pytest-asyncio.readthedocs.io

And for Python mocking:
https://docs.python.org/3.11/library/unittest.mock.html

GUS-W-11790316.