### PR TITLE
Enable some globally disabled pylint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,6 @@ disable = [
     "missing-module-docstring",
     # `no-member` has false positives with orjson
     "no-member",
-    "redefined-outer-name",
-    "too-many-instance-attributes",
 ]
 enable = [
     "useless-suppression",

--- a/salesforce_functions/_internal/app.py
+++ b/salesforce_functions/_internal/app.py
@@ -194,7 +194,7 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
 
 
 # The ASGI app that will be run by uvicorn.
-app = Starlette(
+asgi_app = Starlette(
     exception_handlers={Exception: _handle_internal_error},
     lifespan=_lifespan,
     routes=[

--- a/salesforce_functions/_internal/cli.py
+++ b/salesforce_functions/_internal/cli.py
@@ -11,7 +11,7 @@ from .config import ConfigError, load_config
 from .function_loader import LoadFunctionError, load_function
 
 PROGRAM_NAME = "sf-functions-python"
-ASGI_APP_IMPORT_STRING = "salesforce_functions._internal.app:app"
+ASGI_APP_IMPORT_STRING = "salesforce_functions._internal.app:asgi_app"
 
 
 def main(args: list[str] | None = None) -> int:

--- a/salesforce_functions/_internal/cloud_event.py
+++ b/salesforce_functions/_internal/cloud_event.py
@@ -100,7 +100,7 @@ class SalesforceFunctionContext:
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
-class SalesforceFunctionsCloudEvent:
+class SalesforceFunctionsCloudEvent:  # pylint: disable=too-many-instance-attributes
     id: str
     source: str
     spec_version: str

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,7 +9,7 @@ import pytest
 from pytest import CaptureFixture
 from starlette.testclient import TestClient
 
-from salesforce_functions._internal.app import PROJECT_PATH_ENV_VAR, app
+from salesforce_functions._internal.app import PROJECT_PATH_ENV_VAR, asgi_app
 
 from .utils import (
     WIREMOCK_SERVER_URL,
@@ -413,7 +413,7 @@ level=error msg="{expected_message}"
 
 def test_nonexistent_path() -> None:
     with patch.dict(os.environ, {PROJECT_PATH_ENV_VAR: "tests/fixtures/basic"}):
-        with TestClient(app) as client:
+        with TestClient(asgi_app) as client:
             response = client.post("/nonexistent")
 
     assert response.status_code == 404
@@ -421,7 +421,7 @@ def test_nonexistent_path() -> None:
 
 def test_unsupported_http_method_get() -> None:
     with patch.dict(os.environ, {PROJECT_PATH_ENV_VAR: "tests/fixtures/basic"}):
-        with TestClient(app) as client:
+        with TestClient(asgi_app) as client:
             response = client.get("/")
 
     assert response.status_code == 405
@@ -429,7 +429,7 @@ def test_unsupported_http_method_get() -> None:
 
 def test_unsupported_http_method_delete() -> None:
     with patch.dict(os.environ, {PROJECT_PATH_ENV_VAR: "tests/fixtures/basic"}):
-        with TestClient(app) as client:
+        with TestClient(asgi_app) as client:
             response = client.delete("/")
 
     assert response.status_code == 405

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ import orjson
 from httpx import Response
 from starlette.testclient import TestClient
 
-from salesforce_functions._internal.app import PROJECT_PATH_ENV_VAR, app
+from salesforce_functions._internal.app import PROJECT_PATH_ENV_VAR, asgi_app
 
 WIREMOCK_SERVER_URL = "http://localhost:12345"
 
@@ -111,7 +111,9 @@ def invoke_function(
         headers = generate_cloud_event_headers()
 
     with patch.dict(os.environ, {PROJECT_PATH_ENV_VAR: fixture_path}):
-        with TestClient(app, raise_server_exceptions=raise_server_exceptions) as client:
+        with TestClient(
+            asgi_app, raise_server_exceptions=raise_server_exceptions
+        ) as client:
             response = client.post("/", headers=headers, json=json, content=content)
 
     return response


### PR DESCRIPTION
By renaming `app` to `asgi_app` to fix `redefined-outer-name`, and for `too-many-instance-attributes` moving it to be a line-specific disable instead of being disabled globally.

Also adds `tests/__init__.py` to resolve an import related pylint warning that only shows up in the IDE (after #75), and not the CLI/CI. (Presumably due to the way the IDE plugin runs pylint when linting a single file.)