### PR TITLE
Make `mock_event` generate a unique event ID each time it is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The `testing.mock_event` function now generates a unique event ID each time it is called.
 
 ## [0.4.0] - 2023-01-25
 

--- a/salesforce_functions/testing.py
+++ b/salesforce_functions/testing.py
@@ -48,7 +48,7 @@ T = TypeVar("T")
 def mock_event(
     *,
     data: T,
-    id: str = str(uuid4()),  # pylint: disable=redefined-builtin
+    id: str | None = None,  # pylint: disable=redefined-builtin
     type: str = "com.salesforce.function.invoke.sync",  # pylint: disable=redefined-builtin
     source: str = "urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
     time: datetime = datetime.today(),
@@ -67,7 +67,7 @@ def mock_event(
     ```
     """
     return InvocationEvent(
-        id=id,
+        id=id if id is not None else str(uuid4()),
         type=type,
         source=source,
         data=data,


### PR DESCRIPTION
Previously the ID was generated at import time and then would not change from one invocation to the next.

Moving the `uuid4()` call out of the function signature also has the benefit that the UUID string doesn't appear in the auto-generated docs, which was causing the generated content to change every time the docs tool was run.

GUS-W-12442238.