### PR TITLE
Remove target Python version from the Black configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ features = [
 path = "salesforce_functions/__version__.py"
 
 [tool.black]
-target-version = ['py310', 'py311']
 extend-exclude = "(tests/fixtures/invalid_syntax_error/main.py)"
 
 [tool.coverage.coverage_conditional_plugin.rules]


### PR DESCRIPTION
Since it's redundant as of Black 23.1.0 (#81):
https://github.com/psf/black/releases/tag/23.1.0