### PR TITLE
Add a VSCode launch.json configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Serve Python Function",
+      "type": "python",
+      "request": "launch",
+      "module": "salesforce_functions",
+      "args": ["serve", "--port", "8080", "${fileDirname}"],
+      "justMyCode": true,
+    },
+  ]
+}


### PR DESCRIPTION
To make debugging the runtime easier.

Now in VSCode, the "Serve Python Function" debug option can be selected when viewing any of the functions fixtures.

The config is identical to that documented in the upcoming Python Functions docs on the Salesforce Developer site.

See:
https://code.visualstudio.com/docs/python/debugging

GUS-W-12482023.