### PR TITLE
Add docstrings to the data API class attributes missing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added missing class attribute docstrings to `SalesforceRestApiError`, `InnerSalesforceRestApiError` and `ReferenceId`.
 - Updated the docstrings for the public APIs to align with the style guidelines.
 - Updated the user-facing error and CLI messages to align with the style guidelines.
 

--- a/salesforce_functions/data_api/exceptions.py
+++ b/salesforce_functions/data_api/exceptions.py
@@ -1,21 +1,13 @@
 from dataclasses import dataclass
 
+# The order in `__all__` is the in which pdoc3 will display the classes in the docs.
 __all__ = [
-    "InnerSalesforceRestApiError",
     "DataApiError",
-    "MissingIdFieldError",
     "SalesforceRestApiError",
+    "InnerSalesforceRestApiError",
+    "MissingIdFieldError",
     "UnexpectedRestApiResponsePayload",
 ]
-
-
-@dataclass(frozen=True, kw_only=True, slots=True)
-class InnerSalesforceRestApiError:
-    """An error returned from the Salesforce REST API."""
-
-    message: str
-    error_code: str
-    fields: list[str]
 
 
 class DataApiError(Exception):
@@ -26,7 +18,24 @@ class DataApiError(Exception):
 class SalesforceRestApiError(DataApiError):
     """Raised when the Salesforce REST API signalled error(s)."""
 
-    api_errors: list[InnerSalesforceRestApiError]
+    api_errors: list["InnerSalesforceRestApiError"]
+    """A list of one or more errors returned from the Salesforce REST API."""
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class InnerSalesforceRestApiError:
+    """An error returned from the Salesforce REST API."""
+
+    message: str
+    """The description of this error."""
+    error_code: str
+    """The error code for this error."""
+    fields: list[str]
+    """
+    The field names where the error occurred.
+
+    This will be empty for errors that are not related to a specific field.
+    """
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/salesforce_functions/data_api/exceptions.py
+++ b/salesforce_functions/data_api/exceptions.py
@@ -19,7 +19,7 @@ class SalesforceRestApiError(DataApiError):
     """Raised when the Salesforce REST API signalled error(s)."""
 
     api_errors: list["InnerSalesforceRestApiError"]
-    """A list of one or more errors returned from the Salesforce REST API."""
+    """A list of one or more errors returned from Salesforce REST API."""
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -34,7 +34,7 @@ class InnerSalesforceRestApiError:
     """
     The field names where the error occurred.
 
-    This will be empty for errors that are not related to a specific field.
+    This will be empty for errors that aren't related to a specific field.
     """
 
 

--- a/salesforce_functions/data_api/reference_id.py
+++ b/salesforce_functions/data_api/reference_id.py
@@ -6,9 +6,10 @@ __all__ = ["ReferenceId"]
 @dataclass(frozen=True, kw_only=True, slots=True)
 class ReferenceId:
     """
-    A reference id for an operation inside a `UnitOfWork`.
+    A reference ID for an operation inside a `UnitOfWork`.
 
     Used to reference results of other operations inside the same unit of work.
     """
 
     id: str
+    """The internal identifier of this `ReferenceId`."""


### PR DESCRIPTION
The `SalesforceRestApiError`, `InnerSalesforceRestApiError` and `ReferenceId` data API classes were missing docstrings on their class attributes, which results in `pdoc3` auto-generating a confusing description, eg:

```
* `id: str`
    Return an attribute of instance, which is of type owner.
```

Now, the explicitly set docstrings are shown instead.

In addition, the order of the exceptions in `data_api.exceptions` has been adjusted, so that the exceptions are displayed in the docs in a more intuitive order (base class first etc).

GUS-W-12442866.