### PR TITLE
Improve `DataAPI` exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `DataAPI` now raises the new `data_api.exceptions.ClientError` exception when an exception in
+  the underlying HTTP library occurs, rather than exposing that library's exceptions directly.
+- `MissingIdFieldError` has been renamed to `MissingFieldError` and the name of the missing
+  field is now exposed in the exception value.
 - Added missing class attribute docstrings to `SalesforceRestApiError`, `InnerSalesforceRestApiError` and `ReferenceId`.
 - Updated the docstrings for the public APIs to align with the style guidelines.
 - Updated the user-facing error and CLI messages to align with the style guidelines.
 
 ### Fixed
 
+- All `DataAPI` exceptions now have suitable string representations, making it easier to diagnose
+  errors seen in function logs.
 - The `testing.mock_event` function now generates a unique event ID each time it is called.
 
 ## [0.4.0] - 2023-01-25

--- a/salesforce_functions/data_api/_requests.py
+++ b/salesforce_functions/data_api/_requests.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 
 from .exceptions import (
     InnerSalesforceRestApiError,
-    MissingIdFieldError,
+    MissingFieldError,
     SalesforceRestApiError,
     UnexpectedRestApiResponsePayload,
 )
@@ -96,13 +96,17 @@ class CreateRecordRestApiRequest(RestApiRequest[str]):
         if isinstance(json_body, dict):
             return str(json_body["id"])
 
-        raise UnexpectedRestApiResponsePayload()  # pragma: no cover
+        raise UnexpectedRestApiResponsePayload(
+            "The create record API response payload does not match the expected structure."
+        )  # pragma: no cover
 
 
 class UpdateRecordRestApiRequest(RestApiRequest[str]):
     def __init__(self, record: Record):
         if "Id" not in record.fields:
-            raise MissingIdFieldError()
+            raise MissingFieldError(
+                "The 'Id' field is required, but is not present in the given Record."
+            )
 
         self._record = record
 
@@ -220,7 +224,9 @@ class CompositeGraphRestApiRequest(RestApiRequest[dict[ReferenceId, str]]):
 
             return result
 
-        raise UnexpectedRestApiResponsePayload()  # pragma: no cover
+        raise UnexpectedRestApiResponsePayload(
+            "The composite graph API response payload does not match the expected structure."
+        )  # pragma: no cover
 
 
 async def _process_records_response(
@@ -232,7 +238,9 @@ async def _process_records_response(
     if isinstance(json_body, dict):
         return await _parse_record_query_result(json_body, download_file_fn)
 
-    raise UnexpectedRestApiResponsePayload()  # pragma: no cover
+    raise UnexpectedRestApiResponsePayload(
+        "The API response payload does not match the expected structure."
+    )  # pragma: no cover
 
 
 async def _parse_record_query_result(
@@ -312,4 +320,6 @@ def _parse_errors(json_errors: Json | None) -> list[InnerSalesforceRestApiError]
             for json_error in json_errors
         ]
 
-    raise UnexpectedRestApiResponsePayload()  # pragma: no cover
+    raise UnexpectedRestApiResponsePayload(
+        "The API response payload does not match the expected structure."
+    )  # pragma: no cover

--- a/salesforce_functions/data_api/_requests.py
+++ b/salesforce_functions/data_api/_requests.py
@@ -97,7 +97,7 @@ class CreateRecordRestApiRequest(RestApiRequest[str]):
             return str(json_body["id"])
 
         raise UnexpectedRestApiResponsePayload(
-            "The create record API response payload does not match the expected structure."
+            "The create record API response payload doesn't match the expected structure."
         )  # pragma: no cover
 
 
@@ -105,7 +105,7 @@ class UpdateRecordRestApiRequest(RestApiRequest[str]):
     def __init__(self, record: Record):
         if "Id" not in record.fields:
             raise MissingFieldError(
-                "The 'Id' field is required, but is not present in the given Record."
+                "The 'Id' field is required, but isn't present in the given Record."
             )
 
         self._record = record
@@ -225,7 +225,7 @@ class CompositeGraphRestApiRequest(RestApiRequest[dict[ReferenceId, str]]):
             return result
 
         raise UnexpectedRestApiResponsePayload(
-            "The composite graph API response payload does not match the expected structure."
+            "The composite graph API response payload doesn't match the expected structure."
         )  # pragma: no cover
 
 
@@ -239,7 +239,7 @@ async def _process_records_response(
         return await _parse_record_query_result(json_body, download_file_fn)
 
     raise UnexpectedRestApiResponsePayload(
-        "The API response payload does not match the expected structure."
+        "The API response payload doesn't match the expected structure."
     )  # pragma: no cover
 
 
@@ -321,5 +321,5 @@ def _parse_errors(json_errors: Json | None) -> list[InnerSalesforceRestApiError]
         ]
 
     raise UnexpectedRestApiResponsePayload(
-        "The API response payload does not match the expected structure."
+        "The API response payload doesn't match the expected structure."
     )  # pragma: no cover

--- a/salesforce_functions/data_api/exceptions.py
+++ b/salesforce_functions/data_api/exceptions.py
@@ -24,7 +24,7 @@ class SalesforceRestApiError(DataApiError):
 
     def __str__(self) -> str:
         errors_list = "\n---\n".join(str(error) for error in self.api_errors)
-        return f"The Salesforce REST API reported the following error(s):\n---\n{errors_list}"
+        return f"Salesforce REST API reported the following error(s):\n---\n{errors_list}"
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -53,7 +53,7 @@ class MissingFieldError(DataApiError):
 
 
 class ClientError(DataApiError):
-    """Raised when the API request failed due to a connection error, timeout or malformed HTTP response."""
+    """Raised when the API request failed due to a connection error, timeout, or malformed HTTP response."""
 
 
 class UnexpectedRestApiResponsePayload(DataApiError):

--- a/salesforce_functions/data_api/exceptions.py
+++ b/salesforce_functions/data_api/exceptions.py
@@ -5,7 +5,8 @@ __all__ = [
     "DataApiError",
     "SalesforceRestApiError",
     "InnerSalesforceRestApiError",
-    "MissingIdFieldError",
+    "MissingFieldError",
+    "ClientError",
     "UnexpectedRestApiResponsePayload",
 ]
 
@@ -20,6 +21,10 @@ class SalesforceRestApiError(DataApiError):
 
     api_errors: list["InnerSalesforceRestApiError"]
     """A list of one or more errors returned from Salesforce REST API."""
+
+    def __str__(self) -> str:
+        errors_list = "\n---\n".join(str(error) for error in self.api_errors)
+        return f"The Salesforce REST API reported the following error(s):\n---\n{errors_list}"
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -37,12 +42,19 @@ class InnerSalesforceRestApiError:
     This will be empty for errors that aren't related to a specific field.
     """
 
+    def __str__(self) -> str:
+        # The error message includes the field names, so `self.fields` is intentionally not
+        # included, as the string representation is for human not programmatic consumption.
+        return f"{self.error_code} error:\n{self.message}"
 
-@dataclass(frozen=True, kw_only=True, slots=True)
-class MissingIdFieldError(DataApiError):
-    """Raised when the given Record must contain an `Id` field, but none was found."""
+
+class MissingFieldError(DataApiError):
+    """Raised when the given `Record` must contain a field, but no such field was found."""
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
+class ClientError(DataApiError):
+    """Raised when the API request failed due to a connection error, timeout or malformed HTTP response."""
+
+
 class UnexpectedRestApiResponsePayload(DataApiError):
     """Raised when the Salesforce REST API returned an unexpected payload."""

--- a/salesforce_functions/data_api/exceptions.py
+++ b/salesforce_functions/data_api/exceptions.py
@@ -24,7 +24,9 @@ class SalesforceRestApiError(DataApiError):
 
     def __str__(self) -> str:
         errors_list = "\n---\n".join(str(error) for error in self.api_errors)
-        return f"Salesforce REST API reported the following error(s):\n---\n{errors_list}"
+        return (
+            f"Salesforce REST API reported the following error(s):\n---\n{errors_list}"
+        )
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -471,7 +471,7 @@ async def test_update_with_binary_data_from_bytearray() -> None:
 async def test_update_without_id_field() -> None:
     data_api = new_data_api()
     expected_message = (
-        r"The 'Id' field is required, but is not present in the given Record\.$"
+        r"The 'Id' field is required, but isn't present in the given Record\.$"
     )
 
     with pytest.raises(MissingFieldError, match=expected_message):
@@ -736,7 +736,7 @@ async def test_salesforce_rest_api_error_string_representation() -> None:
     )
     assert (
         str(single_api_error)
-        == """The Salesforce REST API reported the following error(s):
+        == """Salesforce REST API reported the following error(s):
 ---
 MALFORMED_QUERY error:
 unexpected token: SELEKT"""
@@ -766,7 +766,7 @@ unexpected token: SELEKT"""
     )
     assert (
         str(multiple_api_errors)
-        == """The Salesforce REST API reported the following error(s):
+        == """Salesforce REST API reported the following error(s):
 ---
 NOT_FOUND error:
 The requested resource does not exist

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -15,8 +15,9 @@ from salesforce_functions.data_api import (
 )
 from salesforce_functions.data_api import DataAPI
 from salesforce_functions.data_api.exceptions import (
+    ClientError,
     InnerSalesforceRestApiError,
-    MissingIdFieldError,
+    MissingFieldError,
     SalesforceRestApiError,
     UnexpectedRestApiResponsePayload,
 )
@@ -33,14 +34,23 @@ def new_data_api(session: ClientSession | None = None) -> DataAPI:
     )
 
 
+async def test_client_error() -> None:
+    data_api = DataAPI(org_domain_url="", api_version="", access_token="")
+    expected_message = r"An error occurred while making the request: InvalidURL: .+$"
+
+    with pytest.raises(ClientError, match=expected_message):
+        await data_api.query("SELECT Name FROM Account")
+
+
 @pytest.mark.requires_wiremock
 async def test_unexpected_response() -> None:
     data_api = new_data_api()
+    expected_message = (
+        r"The server didn't respond with valid JSON: JSONDecodeError: .+$"
+    )
 
-    with pytest.raises(UnexpectedRestApiResponsePayload) as exception_info:
+    with pytest.raises(UnexpectedRestApiResponsePayload, match=expected_message):
         await data_api.query("SELECT Name FROM FruitVendor__c")
-
-    assert exception_info.value == UnexpectedRestApiResponsePayload()
 
 
 @pytest.mark.requires_wiremock
@@ -460,13 +470,14 @@ async def test_update_with_binary_data_from_bytearray() -> None:
 @pytest.mark.requires_wiremock
 async def test_update_without_id_field() -> None:
     data_api = new_data_api()
+    expected_message = (
+        r"The 'Id' field is required, but is not present in the given Record\.$"
+    )
 
-    with pytest.raises(MissingIdFieldError) as exception_info:
+    with pytest.raises(MissingFieldError, match=expected_message):
         await data_api.update(
             Record(type="Movie__c", fields={"ReleaseDate__c": "1980-05-21"})
         )
-
-    assert exception_info.value == MissingIdFieldError()
 
 
 @pytest.mark.requires_wiremock
@@ -711,3 +722,62 @@ async def test_session() -> None:
             "SELECT Id, VersionData FROM ContentVersion"
         )
         assert second_result.total_size == 1
+
+
+async def test_salesforce_rest_api_error_string_representation() -> None:
+    single_api_error = SalesforceRestApiError(
+        api_errors=[
+            InnerSalesforceRestApiError(
+                message="unexpected token: SELEKT",
+                error_code="MALFORMED_QUERY",
+                fields=[],
+            )
+        ]
+    )
+    assert (
+        str(single_api_error)
+        == """The Salesforce REST API reported the following error(s):
+---
+MALFORMED_QUERY error:
+unexpected token: SELEKT"""
+    )
+
+    multiple_api_errors = SalesforceRestApiError(
+        api_errors=[
+            InnerSalesforceRestApiError(
+                message="The requested resource does not exist",
+                error_code="NOT_FOUND",
+                fields=[],
+            ),
+            InnerSalesforceRestApiError(
+                message="\nSELECT Bacon__c FROM Account LIMIT 2\n       ^\nERROR at Row:1:Column:8"
+                "\nNo such column 'Bacon__c' on entity 'Account'. If you are attempting to use a"
+                " custom field, be sure to append the '__c' after the custom field name. Please"
+                " reference your WSDL or the describe call for the appropriate names.",
+                error_code="INVALID_FIELD",
+                fields=[],
+            ),
+            InnerSalesforceRestApiError(
+                message="Rating: bad value for restricted picklist field: Terrible",
+                error_code="INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST",
+                fields=["Rating__c"],
+            ),
+        ]
+    )
+    assert (
+        str(multiple_api_errors)
+        == """The Salesforce REST API reported the following error(s):
+---
+NOT_FOUND error:
+The requested resource does not exist
+---
+INVALID_FIELD error:
+
+SELECT Bacon__c FROM Account LIMIT 2
+       ^
+ERROR at Row:1:Column:8
+No such column 'Bacon__c' on entity 'Account'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names.
+---
+INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST error:
+Rating: bad value for restricted picklist field: Terrible"""  # noqa: E501
+    )


### PR DESCRIPTION
* Adds a new `ClientError` exception, which wraps the `aiohttp.ClientError` exception (which can occur in the case of connection errors, timeouts or other unexpected HTTP errors): https://docs.aiohttp.org/en/stable/client_reference.html#client-exceptions
* `MissingIdFieldError` has been renamed to `MissingFieldError` and the name of the missing field is now exposed in the exception value.
* All `DataAPI` exceptions now have suitable string representations, making it easier to diagnose errors seen in function logs.

GUS-W-12299777.
GUS-W-12304074.