### PR TITLE
Fix the content type and body handling of data API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Requests made by `DataAPI` now use the correct `Content-Type`.
+- Requests made by `DataAPI` now correctly send an empty body for requests where no body is expected (such as `query` or `delete`).
 - The `testing.mock_event` function now generates a unique event time each time it is called.
 
 ## [0.5.0] - 2023-02-02

--- a/salesforce_functions/data_api/__init__.py
+++ b/salesforce_functions/data_api/__init__.py
@@ -216,7 +216,7 @@ class DataAPI:
                 method,
                 url,
                 headers=self._default_headers(),
-                data=_json_serialize(body),
+                data=None if body is None else _json_serialize(body),
             )
 
             # Using orjson for faster JSON deserialization over the stdlib.
@@ -284,5 +284,5 @@ def _json_serialize(data: Any) -> BytesPayload:
     https://github.com/aio-libs/aiohttp/blob/v3.8.3/aiohttp/payload.py#L386-L403
     """
     return BytesPayload(
-        orjson.dumps(data), content_type="utf-8", encoding="application/json"
+        orjson.dumps(data), encoding="utf-8", content_type="application/json"
     )

--- a/tests/wiremock/mappings/composite-graph-create-tree.json
+++ b/tests/wiremock/mappings/composite-graph-create-tree.json
@@ -13,6 +13,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/composite-graph-create.json
+++ b/tests/wiremock/mappings/composite-graph-create.json
@@ -13,6 +13,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/composite-graph-single-create-error.json
+++ b/tests/wiremock/mappings/composite-graph-single-create-error.json
@@ -13,6 +13,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/composite-graph-single-delete.json
+++ b/tests/wiremock/mappings/composite-graph-single-delete.json
@@ -13,6 +13,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/composite-graph-single-update.json
+++ b/tests/wiremock/mappings/composite-graph-single-update.json
@@ -13,6 +13,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/create-binary-data.json
+++ b/tests/wiremock/mappings/create-binary-data.json
@@ -13,6 +13,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/create-invalid-field.json
+++ b/tests/wiremock/mappings/create-invalid-field.json
@@ -15,6 +15,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/create-invalid-picklist-value.json
+++ b/tests/wiremock/mappings/create-invalid-picklist-value.json
@@ -15,6 +15,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/create-required-field-missing.json
+++ b/tests/wiremock/mappings/create-required-field-missing.json
@@ -15,6 +15,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/create-unknown-object.json
+++ b/tests/wiremock/mappings/create-unknown-object.json
@@ -15,6 +15,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/create.json
+++ b/tests/wiremock/mappings/create.json
@@ -15,6 +15,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/delete-already-deleted.json
+++ b/tests/wiremock/mappings/delete-already-deleted.json
@@ -4,9 +4,15 @@
   "request": {
     "url": "/services/data/v53.0/sobjects/Account/001B000001Lp1G2IAJ",
     "method": "DELETE",
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/delete.json
+++ b/tests/wiremock/mappings/delete.json
@@ -4,9 +4,15 @@
   "request": {
     "url": "/services/data/v53.0/sobjects/Account/001B000001Lp1FxIAJ",
     "method": "DELETE",
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/query-binary-data-subsequent-request.json
+++ b/tests/wiremock/mappings/query-binary-data-subsequent-request.json
@@ -4,9 +4,15 @@
   "request" : {
     "url" : "/services/data/v53.0/sobjects/ContentVersion/0687S00000AX37OQAT/VersionData",
     "method" : "GET",
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/query-binary-data.json
+++ b/tests/wiremock/mappings/query-binary-data.json
@@ -9,9 +9,15 @@
         "equalTo": "SELECT Id, VersionData FROM ContentVersion"
       }
     },
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/query-malformed-soql.json
+++ b/tests/wiremock/mappings/query-malformed-soql.json
@@ -9,9 +9,15 @@
         "equalTo": "SELEKT Name FROM Account"
       }
     },
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/query-unexpected-response.json
+++ b/tests/wiremock/mappings/query-unexpected-response.json
@@ -9,9 +9,15 @@
         "equalTo": "SELECT Name FROM FruitVendor__c"
       }
     },
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/query-unknown-column.json
+++ b/tests/wiremock/mappings/query-unknown-column.json
@@ -9,9 +9,15 @@
         "equalTo": "SELECT Bacon__c FROM Account LIMIT 2"
       }
     },
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/query-with-associated-data.json
+++ b/tests/wiremock/mappings/query-with-associated-data.json
@@ -8,6 +8,20 @@
       "q": {
         "equalTo": "SELECT Name, Owner.Name from Account LIMIT 1"
       }
+    },
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-functions-python:.*"
+      }
     }
   },
   "response" : {

--- a/tests/wiremock/mappings/query-with-next-records-url-2.json
+++ b/tests/wiremock/mappings/query-with-next-records-url-2.json
@@ -4,9 +4,15 @@
   "request": {
     "urlPath": "/services/data/v53.0/query/01gB000003OCxSPIA1-2000",
     "method": "GET",
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/query-with-next-records-url.json
+++ b/tests/wiremock/mappings/query-with-next-records-url.json
@@ -9,9 +9,15 @@
         "equalTo": "SELECT RANDOM_1__c, RANDOM_2__c FROM Random__c"
       }
     },
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/query-with-subquery.json
+++ b/tests/wiremock/mappings/query-with-subquery.json
@@ -9,9 +9,15 @@
         "equalTo": "SELECT Account.Name, (SELECT Contact.FirstName, Contact.LastName FROM Account.Contacts) FROM Account LIMIT 5"
       }
     },
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/query.json
+++ b/tests/wiremock/mappings/query.json
@@ -9,9 +9,15 @@
         "equalTo": "SELECT Name FROM Account"
       }
     },
+    "bodyPatterns" : [ {
+      "absent": true
+    } ],
     "headers": {
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
+      },
+      "Content-Type": {
+        "absent": true
       },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"

--- a/tests/wiremock/mappings/update-binary-data.json
+++ b/tests/wiremock/mappings/update-binary-data.json
@@ -13,6 +13,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/update-invalid-field.json
+++ b/tests/wiremock/mappings/update-invalid-field.json
@@ -15,6 +15,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/update-malformed-id.json
+++ b/tests/wiremock/mappings/update-malformed-id.json
@@ -15,6 +15,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }

--- a/tests/wiremock/mappings/update.json
+++ b/tests/wiremock/mappings/update.json
@@ -15,6 +15,9 @@
       "Authorization": {
         "equalTo": "Bearer EXAMPLE-TOKEN"
       },
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
       "Sforce-Call-Options": {
         "matches": "client=sf-functions-python:.*"
       }


### PR DESCRIPTION
Previously the values for `encoding` and `content-type` were inverted, causing eg:

```
Traceback (most recent call last):
  File ".../.venv/lib/python3.10/site-packages/salesforce_functions/_internal/app.py", line 79, in _handle_function_invocation
    function_result = await function(event, context)
  File ".../functions/hellopython/main.py", line 77, in function
    result = await context.org.data_api.commit_unit_of_work(unit_of_work)
  File ".../.venv/lib/python3.10/site-packages/salesforce_functions/data_api/__init__.py", line 200, in commit_unit_of_work
    return await self._execute(
  File ".../.venv/lib/python3.10/site-packages/salesforce_functions/data_api/__init__.py", line 243, in _execute
    return await rest_api_request.process_response(response.status, json_body)
  File ".../.venv/lib/python3.10/site-packages/salesforce_functions/data_api/_requests.py", line 199, in process_response
    raise SalesforceRestApiError(
salesforce_functions.data_api.exceptions.SalesforceRestApiError: Salesforce REST API reported the following error(s):
---
UNSUPPORTED_MEDIA_TYPE error:
MediaType of 'utf-8' is not supported by this resource
```

In addition (but not the cause of the above error), for data API requests where the body should be none (such as `query` and `delete`), previously the body was still serialised to JSON, resulting in a body of `b'null'`. Now the body is empty in those cases, and the `Content-Type` not set at all.

The Wiremock mappings have been updated to enforce that the `Content-Type` is present and correct for requests that have a body, and that both the `Content-Type` and body are absent when there shouldn't be a body. See:
https://wiremock.org/docs/request-matching/

GUS-W-12496700.