### PR TITLE
Make `mock_event` generate a unique event time each time it is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `testing.mock_event` function now generates a unique event time each time it is called.
 
 ## [0.5.0] - 2023-02-02
 

--- a/salesforce_functions/testing.py
+++ b/salesforce_functions/testing.py
@@ -56,7 +56,7 @@ def mock_event(
     id: str | None = None,  # pylint: disable=redefined-builtin
     type: str = "com.salesforce.function.invoke.sync",  # pylint: disable=redefined-builtin
     source: str = "urn:event:from:salesforce/JS/56.0/00DJS0000000123ABC/apex/ExampleClass:example_function():7",
-    time: datetime = datetime.today(),
+    time: datetime | None = None,
 ) -> InvocationEvent[T]:
     """
     Create an example `InvocationEvent` instance for use in unit tests.
@@ -76,7 +76,7 @@ def mock_event(
         type=type,
         source=source,
         data=data,
-        time=time,
+        time=time if time is not None else datetime.today(),
     )
 
 


### PR DESCRIPTION
Previously the time was generated at import time and then would not change from one invocation to the next.

Moving the `datetime.today()` call out of the function signature also has the benefit that the datetime string doesn't appear in the auto-generated docs, which was causing the generated content to change every time the docs tool was run.

This same fix was applied to the `id` parameter in #77, and should have been applied to `time` at that point too.

GUS-W-12442238.