### PR TITLE
Add `--upgrade` to the getting started guide `pip install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ On a **Microsoft Windows system**:
 Finally, install the dependencies into the virtual environment.
 
 ```sh
-pip3 install -r requirements.txt
+pip3 install --upgrade -r requirements.txt
 ```
 
 Using a virtual environment ensures your function has all required dependencies before you run it.  


### PR DESCRIPTION
So that if the guide is being followed with an existing virtualenv already activated, any existing dependencies (such as the Python functions runtime) are upgraded to pick up recent fixes.