### PR TITLE
Fix CI now that plugin-functions is installed on first use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,10 @@ jobs:
   # - Using the package without the development-only dependencies installed (in case there was a mix up).
   integration-test-sf-cli:
     runs-on: ubuntu-latest
+    env:
+      SFDX_DISABLE_AUTOUPDATE: true
+      SFDX_DISABLE_TELEMETRY: true
+      SFDX_LOG_LEVEL: debug
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -142,6 +146,8 @@ jobs:
           echo "${HOME}/sfdx/bin" >> "${GITHUB_PATH}"
       - name: Output SF CLI version
         run: sf --version
+      - name: Trigger just in time install of the functions CLI plugin
+        run: sf run function start local || true
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -151,7 +157,7 @@ jobs:
       - name: Install the salesforce-functions package and its dependencies
         run: pip install --disable-pip-version-check --progress-bar off .
       - name: Start the template function locally
-        run: sf run function start local &> ../server-output.txt &
+        run: sf run function start local &> /tmp/server-output.txt &
         working-directory: tests/fixtures/template/
       - name: Test the template function's health check response
         # We're testing via the health check since the template function uses the data API,
@@ -161,6 +167,6 @@ jobs:
             echo "Successful response from function"
           else
             echo -e "Function did not respond successfully\n\nServer logs:\n"
-            cat server-output.txt
+            cat /tmp/server-output.txt
             exit 1
           fi


### PR DESCRIPTION
The upstream `sf` CLI now lazy-installs some CLI plugins on first use, such as the `plugin-functions` plugin used in CI:
https://github.com/salesforcecli/cli/blob/27cb011aea1b8d50ef93456bb83f52e384d74f98/package.json#L69

This meant that `plugin-functions` was being installed first before the server could start, causing the smoke test retries/timeouts to be used up before the sever had time to boot:

```
...
curl: (7) Failed to connect to localhost port 8080 after 0 ms: Connection refused
Warning: Problem (retrying all errors). Will retry in 1 seconds. 1 retries 
Warning: left.

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (7) Failed to connect to localhost port 8080 after 0 ms: Connection refused
Function did not respond successfully
```

(https://github.com/heroku/sf-functions-python/actions/runs/4584242743/jobs/8095617867?pr=102#step:8:53)

The server output wasn't being output in the CI logs correctly - fixing that and then enabling the CLI debug output revealed:

```
Run sf run function start local
Successfully validated digital signature for @salesforce/plugin-functions.
Finished digital signature check.
Installing plugin functions...
Installing plugin functions... ⣾
Installing plugin functions... ⣽
Installing plugin functions... ⣻ yarn add v1.22.19
Installing plugin functions... ⢿ [1/4] Resolving packages...
Installing plugin functions... ⡿ [1/4] Resolving packages...
...
```

Now, the plugin install is triggered earlier in CI setup, so that when the background server command is run the plugin has already been installed.

In addition, telemetry and automatic updates have been disabled to clean up the log output and reduce the number of things that could cause issues in the future.